### PR TITLE
docs: Warn about @litexa/assets-wav issue with lame and node 12+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - '10'
-  - '9'
   - '8'
 os:
   - linux

--- a/docs/book/appendix-wav-conversion.md
+++ b/docs/book/appendix-wav-conversion.md
@@ -25,6 +25,11 @@ npm install -g node-gyp
 
 Additionally, you will need to install build tools to compile the 'lame' dependency:
 
+:::danger
+As of July 2019, there is a [known issue](https://github.com/TooTallNate/node-lame/issues/92) with installing `lame` on 
+Node version 12+. To use this extension, we recommend using an LTS version of Node (either 8 or 10).
+:::
+
 * Windows:
 
 ```sh


### PR DESCRIPTION
- docs: Warn about @litexa/assets-wav issue with lame and node 12+
- chore: Update travis.yml to only test Node LTS versions