### PR TITLE
feat: Added @litexa/core version tracking to deployment.

### DIFF
--- a/docs/book/localization.md
+++ b/docs/book/localization.md
@@ -197,7 +197,7 @@ waitForPlayers
     or "playing with $count people"
     with $count = AMAZON.PLAYERS
   ...
-  
+
 ```
 
 The default skill model contains this:
@@ -278,7 +278,7 @@ waitForAnswer
   when AnimalsIntent
     or "the animal is $animal"
     with $animal = animals.build.js:slotBuilder
-  
+
   otherwise
     say "Here is your question again."
     ...
@@ -291,7 +291,7 @@ waitForAnswer
   when PlantsIntent
     or "the plant is $plant"
     with $plant = plants.build.js:slotBuilder
-  
+
   otherwise
     say "Here is your question again."
     ...

--- a/packages/litexa/src/command-line/deploy.coffee
+++ b/packages/litexa/src/command-line/deploy.coffee
@@ -18,7 +18,8 @@ mkdirp = require 'mkdirp'
 path = require 'path'
 
 LoggingChannel = require './loggingChannel'
-{ formatLocationStart } = require("../parser/errors.coffee").lib
+{ formatLocationStart } = require('../parser/errors').lib
+{ validateCoreVersion } = require('./deploy/validators')
 
 module.exports.run = (options) ->
 
@@ -85,16 +86,27 @@ module.exports.run = (options) ->
     logger.error err.message
     return
 
-  require('../deployment/artifacts.coffee').loadArtifacts context, logger
+  require('../deployment/artifacts.coffee').loadArtifacts { context, logger }
+  .then ->
+    lastDeploymentInfo = context.artifacts.get 'lastDeployment'
+    validateCoreVersion {
+      prevCoreVersion: lastDeploymentInfo.coreVersion
+      curCoreVersion: options.coreVersion
+    }
+  .then (proceed) ->
+    if !proceed
+      logger.log "canceled deployment"
+      process.exit(0)
   .then ->
     require('../deployment/git.coffee').getCurrentState()
-    .then (info) ->
-      context.artifacts.save "lastDeployment", {
-        date: (new Date).toLocaleString()
-        deploymentTypes: deploymentTypes
-        git: info
-      }
-      Promise.resolve()
+  .then (info) ->
+    context.artifacts.save "lastDeployment", {
+      date: (new Date).toLocaleString()
+      deploymentTypes: deploymentTypes
+      git: info
+      coreVersion: options.coreVersion
+    }
+    Promise.resolve()
   .then ->
     # neither of these rely on the other, let them interleave
     step1 = []

--- a/packages/litexa/src/command-line/deploy/validators.coffee
+++ b/packages/litexa/src/command-line/deploy/validators.coffee
@@ -1,0 +1,54 @@
+inquirer = require 'inquirer'
+
+# Function to check and handle major/minor mismatch between last deployed @litexa/core
+# version and currently installed version.
+validateCoreVersion = ({
+  prevCoreVersion
+  curCoreVersion
+  inputHandler
+}) ->
+  inquirer = inputHandler ? inquirer
+  # if this is the first deployment, there's nothing to validate
+  unless prevCoreVersion?
+    return true
+
+  # split the version strings, to check major/minor/revision
+  splitCur = curCoreVersion.split('.')
+  splitPrev = prevCoreVersion.split('.')
+
+  diff = null
+  if splitCur[0] != splitPrev[0]
+    diff = "major"
+  else if splitCur[1] != splitPrev[1]
+    diff = "minor"
+
+  result = { proceed: true }
+
+  if diff?
+    msg = "WARNING: This project was last deployed with version #{prevCoreVersion} of
+    @litexa/core. A different #{diff} version #{curCoreVersion} is currently installed. Are you
+    sure you want to proceed?"
+    result = await inquirer.prompt({
+      type: 'list'
+      name: 'proceed'
+      message: msg
+      default: {
+        value: 'yes'
+      }
+      choices: [
+        {
+          name: 'Yes (I am aware there might have been breaking changes between these versions)'
+          value: true
+        }
+        {
+          name: "No (I will install the last deployed #{diff} version of @litexa/core)"
+          value: false
+        }
+      ]
+    })
+
+  return result.proceed
+
+module.exports = {
+  validateCoreVersion
+}

--- a/packages/litexa/src/command-line/generate.coffee
+++ b/packages/litexa/src/command-line/generate.coffee
@@ -33,7 +33,7 @@ config = require './project-config'
 module.exports.run = (options) ->
   logger = new LoggingChannel({
       logStream: options.logger ? console
-      logPrefix:'generator'
+      logPrefix: 'generator'
       verbose: options.verbose
     })
   # absent any other options, generate all assets that don't exist

--- a/packages/litexa/src/command-line/isp.coffee
+++ b/packages/litexa/src/command-line/isp.coffee
@@ -47,7 +47,7 @@ module.exports =
       @askProfile = context.deploymentOptions?.askProfile
       @ispDir = path.join skill.projectInfo?.root, 'isp'
 
-      await loadArtifacts context, @logger
+      await loadArtifacts { context, @logger }
       @artifacts = context.artifacts
       @skillId = @artifacts.get 'skillId'
 

--- a/packages/litexa/src/command-line/loggingChannel.coffee
+++ b/packages/litexa/src/command-line/loggingChannel.coffee
@@ -173,4 +173,3 @@ class LoggingChannel
   identity = (x) -> x
 
 module.exports = LoggingChannel
-

--- a/packages/litexa/src/command-line/router.coffee
+++ b/packages/litexa/src/command-line/router.coffee
@@ -144,6 +144,7 @@ module.exports.run = ->
         watch: cmd.watch
         verbose: cmd.parent.verbose
         cache: cmd.cache
+        coreVersion: packageVersion
       await require('./deploy.coffee').run options
 
   program

--- a/packages/litexa/src/deployment/artifacts.coffee
+++ b/packages/litexa/src/deployment/artifacts.coffee
@@ -56,7 +56,7 @@ class Artifacts
 
 exports.Artifacts = Artifacts
 
-exports.loadArtifacts = (context, logger) ->
+exports.loadArtifacts = ({ context, logger }) ->
   filename = path.join context.projectRoot, 'artifacts.json'
   readFilePromise filename, 'utf8'
   .catch (err) ->

--- a/packages/litexa/test/specs/command-line/deploy/validators.spec.coffee
+++ b/packages/litexa/test/specs/command-line/deploy/validators.spec.coffee
@@ -1,0 +1,92 @@
+
+###
+
+ * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ * Copyright 2019 Amazon.com (http://amazon.com/), Inc. or its affiliates. All Rights Reserved.
+ * These materials are licensed as "Restricted Program Materials" under the Program Materials
+ * License Agreement (the "Agreement") in connection with the Amazon Alexa voice service.
+ * The Agreement is available at https://developer.amazon.com/public/support/pml.html.
+ * See the Agreement for the specific terms and conditions of the Agreement. Capitalized
+ * terms not defined in this file have the meanings given to them in the Agreement.
+ * ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+###
+
+
+{ assert, expect } = require('chai')
+{ fake, spy } = require('sinon')
+
+{ validateCoreVersion } = require('../../../../src/command-line/deploy/validators')
+
+describe 'Version validator', ->
+  fakeInquirer = undefined
+  promptSpy = undefined
+
+  beforeEach ->
+    fakeInquirer = {
+      prompt: (args) -> fake.returns(Promise.resolve({ proceed: true }))
+    }
+    promptSpy = spy(fakeInquirer, 'prompt')
+
+  it 'detects mismatching major version', ->
+    # cur > prev
+    validateCoreVersion {
+      curCoreVersion: '0.2.0'
+      prevCoreVersion: '0.1.0'
+      inputHandler: fakeInquirer
+    }
+
+    expect(promptSpy.firstCall.args[0]).to.have.property(
+      'message',
+      "WARNING: This project was last deployed with version 0.1.0 of @litexa/core. A
+        different minor version 0.2.0 is currently installed. Are you sure you want to proceed?"
+    )
+
+    # prev > cur
+    validateCoreVersion {
+      curCoreVersion: '0.1.0'
+      prevCoreVersion: '0.2.0'
+      inputHandler: fakeInquirer
+    }
+
+    expect(promptSpy.secondCall.args[0]).to.have.property(
+      'message',
+      "WARNING: This project was last deployed with version 0.2.0 of @litexa/core. A
+        different minor version 0.1.0 is currently installed. Are you sure you want to proceed?"
+    )
+
+  it 'detects mismatching minor version', ->
+    # cur > prev
+    validateCoreVersion {
+      curCoreVersion: '1.0.0'
+      prevCoreVersion: '0.0.0'
+      inputHandler: fakeInquirer
+    }
+
+    expect(promptSpy.firstCall.args[0]).to.have.property(
+      'message',
+      "WARNING: This project was last deployed with version 0.0.0 of @litexa/core. A
+        different major version 1.0.0 is currently installed. Are you sure you want to proceed?"
+    )
+
+    # prev > cur
+    validateCoreVersion {
+      curCoreVersion: '0.1.0'
+      prevCoreVersion: '1.0.0'
+      inputHandler: fakeInquirer
+    }
+
+    expect(promptSpy.secondCall.args[0]).to.have.property(
+      'message',
+      "WARNING: This project was last deployed with version 1.0.0 of @litexa/core. A
+        different major version 0.1.0 is currently installed. Are you sure you want to proceed?"
+    )
+
+  it 'ignores mismatching revision version', ->
+    validateCoreVersion {
+      curCoreVersion: '0.0.1'
+      prevCoreVersion: '0.0.2'
+      inputHandler: fakeInquirer
+    }
+
+    expect(promptSpy.callCount).to.equal(0)


### PR DESCRIPTION
Deploying a Litexa project will now check the previously deployed core version, and warn the user of potentially functionality-breaking version mismatches.

resolves #19