### PR TITLE
feat: added optional raw data dump command to test CLI

### DIFF
--- a/docs/book/testing.md
+++ b/docs/book/testing.md
@@ -291,6 +291,8 @@ effects:
   have them.
   * options are `echo`, `dot`, and `show`, with `show` as
     default
+* `--log-raw-data [logRawData]`: dumps all requests, responses, and
+  DB contents into .test/output.json
 * `--watch/-w`: rerun tests after any file changes in your
   Litexa project. This is handy for the rapid iteration
   stage of development and testing because you can trap

--- a/packages/litexa/src/command-line/router.coffee
+++ b/packages/litexa/src/command-line/router.coffee
@@ -144,6 +144,7 @@ module.exports.run = ->
     .description "executes a project's tests and prints the output to the console."
     .option '--no-strict', 'disable strict testing'
     .option '--device [device]', 'which device to emulate (dot, echo, show)', 'show'
+    .option '--log-raw-data [logRawData]', 'dumps all raw requests, responses, and DB contents in .test/output.json'
     .option '-w, --watch', "watch for file changes, then rerun tests"
     .action (filter, cmd) ->
       errors = validator(
@@ -175,6 +176,7 @@ module.exports.run = ->
         region: cmd.parent.region
         watch: cmd.watch
         device: cmd.device
+        logRawData: cmd.logRawData
       require('./test.coffee').run options
 
   program

--- a/packages/litexa/src/command-line/test.coffee
+++ b/packages/litexa/src/command-line/test.coffee
@@ -79,6 +79,7 @@ module.exports.run = (options) ->
       strictMode: !!options.strict
       region: options.region ? "en-US"
       testDevice: options.device ? 'show'
+      logRawData: options.logRawData
       reportProgress: (str) ->
         process.stdout.write str + "\n"
 

--- a/packages/litexa/src/parser/skill.coffee
+++ b/packages/litexa/src/parser/skill.coffee
@@ -886,6 +886,7 @@ class lib.Skill
     # accumulate output
     successes = 0
     fails = 0
+    failedTests = []
     output = { log:[], cards:[], directives:[], raw:[] }
 
     unless options.singleStep
@@ -905,7 +906,7 @@ class lib.Skill
         totalTime = new Date - firstTimeStamp
         options.reportProgress( "test steps complete #{testCounter-1}/#{totalTests} #{totalTime}ms total" )
         if fails
-          output.summary = "✘ #{successes + fails} tests run, #{fails} failed (#{totalTime}ms)\n"
+          output.summary = "✘ #{successes + fails} tests run, #{fails} failed (#{totalTime}ms)\nFailed tests were:\n  " + failedTests.join("\n  ")
         else
           output.summary = "✔ #{successes} tests run, all passed (#{totalTime}ms)\n"
         unless options.singleStep
@@ -923,9 +924,11 @@ class lib.Skill
       options.reportProgress( "test step #{testCounter++}/#{totalTests} +#{new Date - lastTimeStamp}ms: #{test.name ? test.file?.filename()}" )
       lastTimeStamp = new Date
 
-      test.test testContext, output, (err, successCount, failCount) =>
+      test.test testContext, output, (err, successCount, failCount, failedTestName) =>
         successes += successCount
         fails += failCount
+        if failedTestName
+          failedTests.push(failedTestName)
         if remainingTests.length > 0 and (successCount + failCount) > 0
          output.log.push "\n"
         nextTest()

--- a/packages/litexa/src/parser/testing.coffee
+++ b/packages/litexa/src/parser/testing.coffee
@@ -971,7 +971,11 @@ class lib.Test
         if k[0] == '_'
           delete obj[k]
 
-    output.raw.push rawObject
+    # If turned on via test options, this logs all raw responses/requests and DB contents.
+    # @TODO: For extensive tests, dumping this raw object aborts with a JS Heap OOM error
+    # (during writeFileSync in test.coffee) -> should be addressed.
+    if context.testContext.options?.logRawData?
+      output.raw.push rawObject
 
     if result.err
       rawObject.error = result.err.stack ? '' + result.err
@@ -1094,11 +1098,13 @@ class lib.Test
         output.log.push logs.join('\n')
         successCount = 0
         failCount = 0
+        failedTestName = undefined
         if success
           successCount = 1
         else
           failCount = 1
-        setTimeout (->resultCallback null, successCount, failCount), 1
+          failedTestName = @name
+        setTimeout (->resultCallback null, successCount, failCount, failedTestName), 1
         return
 
       step = remainingSteps.shift()

--- a/tests/preamble.coffee
+++ b/tests/preamble.coffee
@@ -89,7 +89,7 @@ exports.runSkill = (name) ->
         return reject(err)
 
       # Let's run our tests on a 'show', so Display & APL are supported.
-      skill.runTests {testDevice: 'show'}, (err, result) ->
+      skill.runTests { testDevice: 'show', logRawData: true }, (err, result) ->
         if err?
           return reject(err)
         unless result.success


### PR DESCRIPTION
# Raw Data Dump Command for Test CLI

Added an optional raw data dump command for the test CLI.

## Description

If used, this command will enabling dumping of all requests, responses, and DB contents into `.test/output.json`.

This PR also includes changes that enable the output of the names of tests that failed.

## Motivation and Context

To give developers the ability to optionally toggle potentially large and detailed log data during testing.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
