### PR TITLE
feat: multi-intent handlers

### DIFF
--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -408,7 +408,7 @@ By default, Litexa keys any DB entries by the skill session's device ID. If requ
 can be overridden by adding the following function anywhere in the skill's inline code.
 
 ```js
-// The global `litexa` namespace contains compilation-time objects at runtime.
+// The global `litexa` namespace contains compile-time objects at runtime.
 // `overridableFunctions` can be redefined by assigning them to new functionality.
 litexa.overridableFunctions = litexa.overridableFunctions
                               ? litexa.overridableFunctions

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1684,7 +1684,7 @@ when RephraseQuestionIntent
 ```
 
 These types of subordinate statements cannot be mixed; doing so will result in a
-compilation-time error.
+compile time error.
 
 When the `when` statement contains an [Utterance](#utterance), the underlying
 intent name will be automatically generated from that utterance,

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1595,6 +1595,13 @@ user: "my name is" with $name = Cat # this is valid, but can't happen in a real 
 ```
 
 
+## Utterance
+
+An example phrase to be spoken by the user that maps to an intent.
+Utterances in Litexa are defined in [when](#when) statements.
+
+Please read the State Management chapter for more information on intents and utterances.
+
 ## wait
 
 Simulates a designated amount of time to pass in a Litexa test case.
@@ -1656,7 +1663,9 @@ statements.
 
 The content of the statement can be an [Utterance](#utterance), or an
 [Intent Name](#intent-name). In either case, the statement can be followed
-by a series of subordinate [or](#or) utterance statements that offer
+by a series of one of the two following subordinate statements.
+
+1. The statement can be followed by [or](#or) utterance statements that offer
 alternative ways to specify the same intent.
 
 ```coffeescript
@@ -1664,6 +1673,18 @@ when "my name is $name"
   or "I'm $name"
   or "call me $name"
 ```
+
+2. The statement can be followed by [or](#or) intent name statements to have
+these intents share the same handler.
+
+```coffeescript
+when RephraseQuestionIntent
+  or AMAZON.RepeatIntent
+  or UnsureIntent
+```
+
+These types of subordinate statements cannot be mixed; doing so will result in a
+compilation-time error.
 
 When the `when` statement contains an [Utterance](#utterance), the underlying
 intent name will be automatically generated from that utterance,
@@ -1852,7 +1873,7 @@ use a shortcut and return an array of strings for the values key:
 exports.vehicleNames = function() {
   return {
     name: "LIST_OF_TRAVEL_MODES",
-    values: [ "train",
+    values: [
       "train",
       "jet",
       "fly",

--- a/packages/litexa/src/parser/intent.coffee
+++ b/packages/litexa/src/parser/intent.coffee
@@ -300,6 +300,7 @@ class lib.Intent
             refer to a built in intent beginning with `AMAZON.`"
     @builtin = @name in builtInIntents
     @hasContent = false
+    @childIntents = []
 
   report: ->
     "#{@name} {#{k for k of @slots}}"
@@ -366,7 +367,14 @@ class lib.Intent
     Intent.registerUtterance(@location, utterance, @name)
 
   pushAlternate: (parts) ->
+    @hasAlternateUtterance = true
     @pushUtterance new lib.Utterance parts
+
+  pushChildIntent: (intent) ->
+    @childIntents.push(intent.name)
+
+  hasChildIntents: ->
+    return @childIntents.length > 0
 
   pushSlotType: (location, name, type) ->
     if @referenceIntent?

--- a/packages/litexa/src/parser/litexa.pegjs
+++ b/packages/litexa/src/parser/litexa.pegjs
@@ -1192,7 +1192,7 @@ when RephraseQuestionIntent
 ```
 
 These types of subordinate statements cannot be mixed; doing so will result in a
-compilation-time error.
+compile time error.
 
 When the `when` statement contains an [Utterance](#utterance), the underlying
 intent name will be automatically generated from that utterance,

--- a/packages/litexa/src/parser/skill.coffee
+++ b/packages/litexa/src/parser/skill.coffee
@@ -638,7 +638,7 @@ class lib.Skill
         intents: []
 
     for name, state of @states
-      state.toModelV2 output, context
+      state.toModelV2 output, context, @extendedEventNames
 
     for name, type of context.types
       output.languageModel.types.push type

--- a/tests/data/intents/litexa/main.litexa
+++ b/tests/data/intents/litexa/main.litexa
@@ -18,6 +18,36 @@ launch
     say "heard upper"
   when "lower case utterance"
     say "heard lower"
+  when OtherIntentName
+    or "other intent name"
+    -> someState
+
+someState
+  say "in some state"
+
+  when AMAZON.NoIntent
+    or OtherIntentName
+    say "got {context.event.request.intent.name}"
+
+  when "handler is utterance"
+    or lowercase
+    say "hello"
+  
+  when "another intent"
+    or PreviouslyNotDefinedIntentName
+    say "moving to otherState"
+    -> otherState
+
+  otherwise
+    -> someState
+
+otherState
+  when "another intent"
+    or "another intent alternate"
+    say "handled another intent in otherState"
+  
+  when PreviouslyNotDefinedIntentName
+    or "some utterance for this intent"
 
 TEST "capitalization mismatch doesn't matter between intent handler and 'user:' statement"
   launch
@@ -25,3 +55,18 @@ TEST "capitalization mismatch doesn't matter between intent handler and 'user:' 
   alexa: launch, e"heard upper"
   user: "LOWER CASE UTTERANCE"
   alexa: launch, e"heard lower"
+
+TEST "aggregated handlers work for the intents declared in them"
+  launch
+  user: OtherIntentName
+  alexa: someState, e"in some state"
+  user: AMAZON.NoIntent
+  alexa: someState, e"got AMAZON.NoIntent"
+  user: OtherIntentName
+  alexa: someState, e"got OtherIntentName"
+  user: lowercase
+  alexa: someState, e"hello"
+  user: PreviouslyNotDefinedIntentName
+  alexa: otherState, e"moving to otherState"
+  user: "another intent alternate"
+  alexa: otherState, e"handled another intent in otherState"

--- a/tests/data/intents/litexa/main.litexa
+++ b/tests/data/intents/litexa/main.litexa
@@ -31,7 +31,7 @@ someState
 
   when "handler is utterance"
     or lowercase
-    say "hello"
+    say "got {context.event.request.intent.name}"
   
   when "another intent"
     or PreviouslyNotDefinedIntentName
@@ -44,7 +44,7 @@ someState
 otherState
   when "another intent"
     or "another intent alternate"
-    say "handled another intent in otherState"
+    say "otherState got {context.event.request.intent.name}"
   
   when PreviouslyNotDefinedIntentName
     or "some utterance for this intent"
@@ -65,8 +65,8 @@ TEST "aggregated handlers work for the intents declared in them"
   user: OtherIntentName
   alexa: someState, e"got OtherIntentName"
   user: lowercase
-  alexa: someState, e"hello"
+  alexa: someState, e"got lowercase"
   user: PreviouslyNotDefinedIntentName
   alexa: otherState, e"moving to otherState"
   user: "another intent alternate"
-  alexa: otherState, e"handled another intent in otherState"
+  alexa: otherState, e"otherState got ANOTHER_INTENT"

--- a/tests/data/localization/litexa/main.litexa
+++ b/tests/data/localization/litexa/main.litexa
@@ -34,6 +34,11 @@ unusedState
     say "unused state answer"
     END
 
+  when CAT_BREED
+    or AMAZON.HelpIntent
+    say "Got cat breed or help."
+    END
+
 global
   when AMAZON.RepeatIntent
     say "repeat"

--- a/tests/data/sound/litexa/main.litexa
+++ b/tests/data/sound/litexa/main.litexa
@@ -6,6 +6,10 @@ playFile
 playURL
   playMusic "https://www.example.com/sound.mp3"
 
+playSfx
+  soundEffect sound.mp3
+    or sound.mp3
+
 stop
   stopMusic
 
@@ -14,5 +18,7 @@ global
     -> playFile
   when "play url"
     -> playURL
+  when "play random mp3"
+    -> playSfx
   when "stop"
     -> stop

--- a/tests/data/sound/litexa/main.test.litexa
+++ b/tests/data/sound/litexa/main.test.litexa
@@ -4,5 +4,7 @@ TEST "happy path"
   alexa: playFile
   user: "play URL"
   alexa: playURL
+  user: "play random mp3"
+  alexa: playSfx
   user: "stop"
   alexa: stop

--- a/tests/features/localization.spec.coffee
+++ b/tests/features/localization.spec.coffee
@@ -34,6 +34,11 @@ describe 'supports languages folder overrides', ->
     intents = frModel.languageModel.intents.map (intent) -> intent.name
     assert("CAT" not in intents)
 
+  it 'includes intents defined in multi-intent handlers from default language', ->
+    frModel = await preamble.buildSkillModel 'localization', 'fr'
+    intents = frModel.languageModel.intents.map (intent) -> intent.name
+    assert("AMAZON.HelpIntent" in intents)
+
   testCompleteSlotValuesForIntent = (actualSlots, expectedSlots) ->
     for slotValue in actualSlots.values
       assert(slotValue.name.value in expectedSlots)

--- a/tests/features/sound.spec.coffee
+++ b/tests/features/sound.spec.coffee
@@ -27,7 +27,7 @@ describe 'supports the playMusic and stopMusic statements', ->
       assert.equal directives[0].type, 'AudioPlayer.Play'
       assert.equal directives[0].audioItem?.stream?.url, 'https://www.example.com/sound.mp3'
 
-      response = result.raw[3].response.response
+      response = result.raw[4].response.response
       directives = response.directives
       assert.equal directives.length, 1
       assert.equal directives[0].type, 'AudioPlayer.Stop'


### PR DESCRIPTION
# Multi-intent handlers

New syntax shorthand that allows assigning multiple intents to the same handler.

## Description

* Now allows alternatives in `when` handlers to specify intent names as an option. These cannot be intermixed with utterance alternatives.
* Gives a warning that intents which are defined without utterances are not added to the language model (unfortunately this is run twice in `litexa test`)
* Also changes some variables to constants in pegjs.

## Motivation and Context
This feature reduces the need for either an extra state or duplicate code when you may want 2 intents to have the same behavior.

Addresses issue #89.

## Testing

* npm run release
* test skill - litexa model, litexa deploy, litexa test. Verified that the generated handler code is as expected.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
