### PR TITLE
docs: add missing variable to sample for slot builders

### DIFF
--- a/docs/book/state-management.md
+++ b/docs/book/state-management.md
@@ -430,7 +430,7 @@ code in `litexa/slotbuilder.build.js`
 ```javascript
 // litexa/slotbuilder.build.js
 function answerSlots(skill, language){
-  jsonFiles['questions.json'].map( (d) =>
+  let answers = jsonFiles['questions.json'].map( (d) =>
     return d.a.replace(/[,.]/g, ' ');
   );
   return {


### PR DESCRIPTION
Sample didn't compile before, was just missing the variable declaration and assignment for the result of the map operation.