### PR TITLE
feat: made it so that extension interfaces are auto-enabled

### DIFF
--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -7,12 +7,17 @@ visually rich and interactive voice-controlled game experiences. You'll be able 
 for multimodal devices using HTML and web technologies like Canvas 2D, WebAudio, WebGL, 
 JavaScript, and CSS, starting with Echo Show devices and Fire TVs.
 
-The Alexa Web API for Games is currently in Developer Preview. To gain access
+**NOTE**: The Alexa Web API for Games is currently in Developer Preview. To gain access
 to its features & documentation, visit the [Alexa Developer
 Blog](https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/11/apply-for-the-alexa-web-api-for-games-developer-preview)
 for sign-up information.
 
 ## Installation
+
+**WARNING**: The use of this extension is currently reserved for those in the 
+Alexa Web API for Games Developer Preview. If you are not in the Developer Preview 
+and you install this extension, you will not be able to deploy your Alexa skills 
+through Litexa.
 
 The module can be installed globally, which makes it available to any of your 
 Litexa projects:
@@ -59,5 +64,5 @@ the marks can be used to trigger HTML events that interleave with SSML playback.
 For more information, please refer to the official Alexa Web API for Games documentation:
 
 * [Alexa Web API 
-for Games](https://developer.amazon.com/en-US/docs/alexa/web-api-for-games/understand-alexa-web-api-for-games.html)
+for Games Announcement](https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/11/apply-for-the-alexa-web-api-for-games-developer-preview)
 

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -16,8 +16,8 @@ for sign-up information.
 
 **WARNING**: The use of this extension is currently reserved for those in the 
 Alexa Web API for Games Developer Preview. If you are not in the Developer Preview 
-and you install this extension, you will not be able to deploy your Alexa skills 
-through Litexa.
+and you have this extension installed, you will not be able to deploy your Alexa 
+skills through Litexa.
 
 The module can be installed globally, which makes it available to any of your 
 Litexa projects:

--- a/packages/litexa/src/command-line/deploy/manifest.coffee
+++ b/packages/litexa/src/command-line/deploy/manifest.coffee
@@ -294,6 +294,10 @@ buildSkillManifest = (context, manifestContext) ->
   # collect which APIs are actually in use and merge them
   requiredAPIs = {}
   context.skill.collectRequiredAPIs requiredAPIs
+  for k, extension of context.projectInfo.extensions
+    continue unless extension.compiler?.requiredAPIs?
+    for a in extension.compiler.requiredAPIs
+      requiredAPIs[a] = true
   for apiName of requiredAPIs
     found = false
     for i in interfaces


### PR DESCRIPTION
# Made it so that extension interfaces are auto-enabled

## Description

If a skill is utilizing an extension that requires an Alexa interface enablement, Litexa will auto-enable said interface on deployment.

## Motivation and Context

To simplify the skill deployment process even further when using Litexa extensions.

## Testing

Ran unit and integration tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
