### PR TITLE
fix: remove inapplicable warning for not adding events to language model

### DIFF
--- a/packages/litexa/src/parser/state.coffee
+++ b/packages/litexa/src/parser/state.coffee
@@ -307,7 +307,7 @@ class lib.State
       continue if name == '--default--'
       continue if intent.referenceIntent?
       unless intent.hasUtterances
-        unless name in extendedEventNames
+        unless context.skill.testDevice? and (name in extendedEventNames or name.includes('.')) # supported events have '.' in their names
           console.warn "`#{name}` does not have utterances; not adding to language model."
         continue
       try


### PR DESCRIPTION
# Remove warnings about not adding intents with missing utterances for inapplicable events

The warning `'HelloIntent' does not have utterances; not adding to language model.` is a false positive for events (events are not added to language models).

Also, `litexa test` seems to run this twice - once to build the model, once in the test execution? Added a check for testDevice which is set during testing to remove the duplication.

## Description

As of the multi-intent handler change, Litexa will warn in any step when building the model about intents it detects that doesn't have any utterances (besides built-in), that it will not add those intents to the model. It has been detecting events (e.g 'Connections.Response') as such intents, to which the warning doesn't apply because events are not part of the language model.

Events are (as far as we know) guaranteed to have a period in their name, so by adding that as a condition for producing the warning, we would only warn on custom intents that do not contain utterances.

## Motivation and Context

Reduces unnecessary logging.

## Testing
npm run release

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
