### PR TITLE
fix: update globals.d.ts for dynamoDbConfiguration

### DIFF
--- a/packages/litexa/src/command-line/templates/common/typescript/config/globals.d.ts
+++ b/packages/litexa/src/command-line/templates/common/typescript/config/globals.d.ts
@@ -35,6 +35,13 @@ interface S3Configuration {
     uploadParams?: UploadParams[];
 }
 
+interface DynamoDbConfiguration {
+    timeToLive?: {
+        AttributeName: string;
+        secondsToLive: number;
+    }
+}
+
 interface UploadParams {
     filter?: string[];
     params: { [key: string]: any };
@@ -45,6 +52,7 @@ interface Deployment {
     askProfile: string;
     awsProfile: string;
     lambdaConfiguration?: LambdaSettings;
+    dynamoDbConfiguration?: DynamoDbConfiguration;
     s3Configuration: S3Configuration;
     S3BucketName?: string;  // Deprecated. Now using s3Configuration.bucketName.
     invocationSuffix?: string;


### PR DESCRIPTION
# Update globals.d.ts for dynamoDbConfiguration

Forgot to do this as a part of #106 .

## Description

Update the typescript litexa config definition.

## Motivation and Context

If a user is using typescript, a `npm run compile` will error out on litexa config if it uses this field.

## Testing

`litexa generate` with typescript configuration

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
