### PR TITLE
fix: update litexa template dependencies

### DIFF
--- a/packages/litexa/src/command-line/templates/bundled/coffee/package.json
+++ b/packages/litexa/src/command-line/templates/bundled/coffee/package.json
@@ -16,17 +16,17 @@
   "devDependencies": {
     "chai": "4.2.0",
     "coffee-loader": "0.9.0",
-    "coffeescript": "2.3.2",
-    "eslint": "5.13.0",
-    "mocha": "6.2.2",
-    "sinon": "7.2.3",
-    "source-map-support": "0.5.10",
-    "webpack": "4.28.4",
-    "webpack-cli": "3.2.1"
+    "coffeescript": "2.5.0",
+    "eslint": "6.8.0",
+    "mocha": "7.0.0",
+    "sinon": "8.1.0",
+    "source-map-support": "0.5.16",
+    "webpack": "4.41.5",
+    "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "pino": "5.10.6",
-    "pino-pretty": "2.5.0"
+    "pino": "5.16.0",
+    "pino-pretty": "3.5.0"
   },
   "license": "ISC"
 }

--- a/packages/litexa/src/command-line/templates/bundled/javascript/package.json
+++ b/packages/litexa/src/command-line/templates/bundled/javascript/package.json
@@ -15,22 +15,22 @@
   },
   "author": "Amazon",
   "devDependencies": {
-    "@babel/core": "7.2.2",
-    "@babel/preset-env": "7.3.1",
-    "@babel/register": "7.0.0",
-    "babel-eslint": "10.0.1",
-    "babel-plugin-module-resolver": "3.1.3",
+    "@babel/core": "7.8.3",
+    "@babel/preset-env": "7.8.3",
+    "@babel/register": "7.8.3",
+    "babel-eslint": "10.0.3",
+    "babel-plugin-module-resolver": "4.0.0",
     "chai": "4.2.0",
-    "eslint": "5.13.0",
-    "mocha": "6.2.2",
-    "sinon": "7.2.3",
-    "source-map-support": "0.5.10",
-    "webpack": "4.28.4",
-    "webpack-cli": "3.2.1"
+    "eslint": "6.8.0",
+    "mocha": "7.0.0",
+    "sinon": "8.1.0",
+    "source-map-support": "0.5.16",
+    "webpack": "4.41.5",
+    "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "pino": "5.10.6",
-    "pino-pretty": "2.5.0"
+    "pino": "5.16.0",
+    "pino-pretty": "3.5.0"
   },
   "license": "ISC"
 }

--- a/packages/litexa/src/command-line/templates/bundled/typescript/source/package.json
+++ b/packages/litexa/src/command-line/templates/bundled/typescript/source/package.json
@@ -15,26 +15,26 @@
   },
   "author": "Amazon",
   "devDependencies": {
-    "@types/chai": "4.1.7",
-    "@types/mocha": "5.2.5",
-    "@types/node": "10.12.18",
-    "@types/pino": "5.8.3",
-    "@types/sinon": "7.0.5",
+    "@types/chai": "4.2.7",
+    "@types/mocha": "5.2.7",
+    "@types/node": "13.1.8",
+    "@types/pino": "5.15.3",
+    "@types/sinon": "7.5.1",
     "chai": "4.2.0",
-    "mocha": "6.2.2",
-    "sinon": "7.2.3",
-    "source-map-support": "0.5.10",
-    "ts-loader": "5.3.3",
-    "ts-node": "8.0.1",
-    "tsconfig-paths": "3.7.0",
-    "tslint": "5.12.1",
-    "typescript": "3.2.4",
-    "webpack": "4.28.4",
-    "webpack-cli": "3.2.1"
+    "mocha": "7.0.0",
+    "sinon": "8.1.0",
+    "source-map-support": "0.5.16",
+    "ts-loader": "6.2.1",
+    "ts-node": "8.6.2",
+    "tsconfig-paths": "3.9.0",
+    "tslint": "6.0.0",
+    "typescript": "3.7.5",
+    "webpack": "4.41.5",
+    "webpack-cli": "3.3.10"
   },
   "dependencies": {
-    "pino": "5.10.6",
-    "pino-pretty": "2.5.0"
+    "pino": "5.16.0",
+    "pino-pretty": "3.5.0"
   },
   "license": "ISC"
 }

--- a/packages/litexa/src/command-line/templates/common/typescript/config/package.json
+++ b/packages/litexa/src/command-line/templates/common/typescript/config/package.json
@@ -10,8 +10,8 @@
   "author": "Amazon",
   "license": "ISC",
   "devDependencies": {
-    "tsconfig-paths": "3.7.0",
-    "tslint": "5.12.1",
-    "typescript": "3.2.4"
+    "tsconfig-paths": "3.9.0",
+    "tslint": "6.0.0",
+    "typescript": "3.7.5"
   }
 }

--- a/packages/litexa/src/command-line/templates/inlined/typescript/package.json
+++ b/packages/litexa/src/command-line/templates/inlined/typescript/package.json
@@ -12,7 +12,7 @@
   "author": "Amazon",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "10.12.18",
-    "typescript": "3.2.4"
+    "@types/node": "13.1.8",
+    "typescript": "3.7.5"
   }
 }

--- a/packages/litexa/src/command-line/templates/separate/coffee/package.json
+++ b/packages/litexa/src/command-line/templates/separate/coffee/package.json
@@ -13,12 +13,12 @@
   "license": "ISC",
   "devDependencies": {
     "chai": "4.2.0",
-    "coffeescript": "2.3.2",
-    "mocha": "6.2.2",
-    "sinon": "7.2.3"
+    "coffeescript": "2.5.0",
+    "mocha": "7.0.0",
+    "sinon": "8.1.0"
   },
   "dependencies": {
-    "pino": "5.10.6",
-    "pino-pretty": "2.5.0"
+    "pino": "5.16.0",
+    "pino-pretty": "3.5.0"
   }
 }

--- a/packages/litexa/src/command-line/templates/separate/javascript/package.json
+++ b/packages/litexa/src/command-line/templates/separate/javascript/package.json
@@ -7,19 +7,18 @@
     "test": "npx mocha './{,!(node_modules)/**}/*.spec.js'",
     "test:file": "npx mocha",
     "test:watch": "npx mocha './{,!(node_modules)/**}/*.spec.js' --watch",
-    "lint": "npx eslint **/*.js --quiet",
-    "postinstall": "npm prune --production"
+    "lint": "npx eslint **/*.js --quiet"
   },
   "author": "Amazon",
   "license": "ISC",
   "devDependencies": {
     "chai": "4.2.0",
-    "eslint": "5.13.0",
-    "mocha": "6.2.2",
-    "sinon": "7.2.3"
+    "eslint": "6.8.0",
+    "mocha": "7.0.0",
+    "sinon": "8.1.0"
   },
   "dependencies": {
-    "pino": "5.10.6",
-    "pino-pretty": "2.5.0"
+    "pino": "5.16.0",
+    "pino-pretty": "3.5.0"
   }
 }

--- a/packages/litexa/src/command-line/templates/separate/typescript/package.json
+++ b/packages/litexa/src/command-line/templates/separate/typescript/package.json
@@ -15,20 +15,20 @@
   "author": "Amazon",
   "license": "ISC",
   "devDependencies": {
-    "@types/chai": "4.1.7",
-    "@types/mocha": "5.2.5",
-    "@types/node": "10.12.18",
-    "@types/pino": "5.8.3",
+    "@types/chai": "4.2.7",
+    "@types/mocha": "5.2.7",
+    "@types/node": "13.1.8",
+    "@types/pino": "5.15.3",
     "chai": "4.2.0",
-    "mocha": "6.2.2",
-    "source-map-support": "0.5.10",
-    "ts-node": "8.0.1",
-    "tsconfig-paths": "3.7.0",
-    "tslint": "5.12.1",
-    "typescript": "3.2.4"
+    "mocha": "7.0.0",
+    "source-map-support": "0.5.16",
+    "ts-node": "8.6.2",
+    "tsconfig-paths": "3.9.0",
+    "tslint": "6.0.0",
+    "typescript": "3.7.5"
   },
   "dependencies": {
-    "pino": "5.10.6",
-    "pino-pretty": "2.5.0"
+    "pino": "5.16.0",
+    "pino-pretty": "3.5.0"
   }
 }


### PR DESCRIPTION
# Update the dependencies that the Litexa project templates use

## Description

Updated the dependencies that the Litexa project templates use.

## Motivation and Context

To keep the project templates, which are a great entry point and learning experience for Litexa developers, as up-to-date as possible.

## Testing

Full integration tests. 

Generated multiple Litexa projects - one for each template - and ran:
* `litexa deploy`, 
* `litexa test`, 
* and other pre-created NPM scripts like:
  * `npm run compile`,
  * `npm run test`,
  * `npm run lint`. 

Then tested each of the deployed skills.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
