### PR TITLE
fix: Fix path to property named 'title' in APL documentation

### DIFF
--- a/docs/book/screens.md
+++ b/docs/book/screens.md
@@ -291,7 +291,7 @@ The above `data` is then accessed with the parameter `payload`:
     ],
     "item": {
       "type": "Text",
-      "text": "${payload.myDataObject.title}"
+      "text": "${payload.myDataObject.properties.title}"
     }
   }
 }


### PR DESCRIPTION
# Fix path to property named 'title' in APL documentation

## Description

Fix a path within the documentation. Litexas functionality is not affected by this change.
