### PR TITLE
fix: Switched a couple absolute to relative file references.

### DIFF
--- a/packages/litexa/src/command-line/localization.js
+++ b/packages/litexa/src/command-line/localization.js
@@ -5,7 +5,7 @@ const { promisify } = require('util');
 
 const LoggingChannel = require('./loggingChannel');
 const projectConfig = require('./project-config');
-const { Skill } = require('@litexa/core/src/parser/skill');
+const { Skill } = require('../parser/skill');
 
 /* The skill localization object has the following contents:
   {

--- a/packages/litexa/src/parser/say.coffee
+++ b/packages/litexa/src/parser/say.coffee
@@ -7,7 +7,7 @@
 
 lib = module.exports.lib = {}
 
-{ parseFragment } = require('@litexa/core/src/parser/parser')
+{ parseFragment } = require('./parser.coffee')
 { ParserError } = require('./errors.coffee').lib
 { AssetName } = require('./assets.coffee').lib
 {


### PR DESCRIPTION
The absolute file references appear to be causing issues when locally installing the @litexa/core package on Node 10, from scratch. Switching them to local references, to be safe.