### PR TITLE
chore: update inlined typescript npm test scripts to be more accurate

### DIFF
--- a/packages/litexa/src/command-line/templates/inlined/typescript/package.json
+++ b/packages/litexa/src/command-line/templates/inlined/typescript/package.json
@@ -6,8 +6,8 @@
     "compile": "npx tsc",
     "compile:watch": "npx tsc -w",
     "deploy": "npm run compile && litexa deploy",
-    "test": "npm run compile && litexa test",
-    "test:watch": "npm run compile:watch | litexa test -w"
+    "test:litexa": "npm run compile && litexa test",
+    "test:litexa:watch": "npm run compile:watch | litexa test -w"
   },
   "author": "Amazon",
   "license": "ISC",


### PR DESCRIPTION
Update inlined TypeScript template's NPM test script names to be more accurate / match its README.md.