### PR TITLE
docs: Add details on which runtime environment to use for both local …

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Litexa is an Alexa domain specific language, developed for long form multi-turn 
 Its parser and tooling is implemented in Node.js and it compiles into JavaScript that expects Node.js
 as a runtime environment.
 
-**Note:** *Litexa officially supports and works best with Node.js v10.x.*
+**Note:** *Due to a dependency not compatible with Node.js v12 in the @litexa/assets-wav package, the 
+recommended local runtime and default deployment runtime is Node.js v10. If you are not using this
+package, you are welcome to upgrade both your local and runtime environment to Node.js v12.*
 
 Full documentation is available at <https://litexa.com>
 


### PR DESCRIPTION
# Provide reasoning for which runtime environment to use.

There are reasons why node 10 is the default supported version, even though 12 is newer.

## Description

Update to #122 

## Motivation and Context

To be more specific and add reasoning to help determine which runtime environment to use.

## Testing

npm run docs:build; markdown preview

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
