### PR TITLE
docs: add more links to lambda config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ as a runtime environment.
 
 **Note:** *Due to a dependency not compatible with Node.js v12 in the @litexa/assets-wav package, the 
 recommended local runtime and default deployment runtime is Node.js v10. If you are not using this
-package, you are welcome to upgrade both your local and runtime environment to Node.js v12.*
+package, you are welcome to upgrade both your local and runtime environment to Node.js v12. Refer to our
+[deployment documentation](./docs/book/deployment.md#lambda-configuration-optional) for more configuration 
+details.*
 
 Full documentation is available at <https://litexa.com>
 

--- a/docs/book/appendix-default-aws-settings.md
+++ b/docs/book/appendix-default-aws-settings.md
@@ -18,6 +18,8 @@ gives this the skill requests's `context.System.device.deviceId` field, by defau
 ## Lambda
 
 * Runtime is set to `nodejs10.x`, by default.
+  * You can modify the Lambda's runtime version by changing your Litexa configuration. Details can be
+    found in our [deployment chapter](/book/deployment.html#lambda-configuration-optional).
   * You can check the runtime deprecation schedule in the [Lambda Runtime Support
     Policy](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).
 * Creates/uses an alias, which is included as part of the skill endpoint


### PR DESCRIPTION
Where we explain Lambda runtime environments and its default settings, add link to lambda config section of deployment chapter.