### PR TITLE
ci: add node 12 to build matrix

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2016]
-        node: [10]
+        node: [10, 12]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2016]
+        os: [windows-2019]
         node: [10, 12]
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
     - packages/*/node_modules
 
 install:
-  - if [ $TRAVIS_NODE_VERSION == "12" ]; then npm install --no-optional; else npm install; fi
+  - if [ $TRAVIS_NODE_VERSION == "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi
 
 stages:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
+
 node_js:
   - '10'
+  - '12'
+
 os:
   - linux
   - osx
@@ -14,6 +17,9 @@ cache:
     - node_modules
     - packages/*/node_modules
 
+install:
+  - if [ $TRAVIS_NODE_VERSION == "12" ]; then npm install --no-optional; else npm install; fi
+
 stages:
   - name: build
   - name: coverage
@@ -26,7 +32,7 @@ stages:
 jobs:
   include:
     - stage: build
-      name: 'Compile'
+      name: 'Build'
       script: npm run build
       before_script:
         - echo "$TRAVIS_EVENT_TYPE"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:build": "npm run docs:reference && npx vuepress build docs",
     "docs:dev": "npx vuepress dev docs",
     "docs:reference": "cd ./packages/litexa && npm run rdoc && npx move-cli ./src/documentation/reference.md ../../docs/reference/README.md && cd ../../",
-    "postinstall": "npx lerna bootstrap && npx lerna link convert",
+    "postinstall": "npx lerna link convert",
     "release": "npm run build && npm run coverage",
     "test": "npx lerna exec --concurrency 1 npm run test"
   },
@@ -27,13 +27,15 @@
   ],
   "dependencies": {
     "@litexa/apl": "file:packages/litexa-apl",
-    "@litexa/assets-wav": "file:packages/litexa-assets-wav",
     "@litexa/core": "file:packages/litexa",
     "@litexa/deploy-aws": "file:packages/litexa-deploy-aws",
     "@litexa/gadgets": "file:packages/litexa-gadgets",
     "@litexa/html": "file:packages/litexa-html",
     "@litexa/integration-tests": "file:tests",
     "@litexa/render-template": "file:packages/litexa-render-template"
+  },
+  "optionalDependencies": {
+    "@litexa/assets-wav": "file:packages/litexa-assets-wav"
   },
   "devDependencies": {
     "assert": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:build": "npm run docs:reference && npx vuepress build docs",
     "docs:dev": "npx vuepress dev docs",
     "docs:reference": "cd ./packages/litexa && npm run rdoc && npx move-cli ./src/documentation/reference.md ../../docs/reference/README.md && cd ../../",
-    "postinstall": "npx lerna link convert",
+    "postinstall": "lerna link convert",
     "release": "npm run build && npm run coverage",
     "test": "npx lerna exec --concurrency 1 npm run test"
   },

--- a/package.json
+++ b/package.json
@@ -27,15 +27,13 @@
   ],
   "dependencies": {
     "@litexa/apl": "file:packages/litexa-apl",
+    "@litexa/assets-wav": "file:packages/litexa-assets-wav",
     "@litexa/core": "file:packages/litexa",
     "@litexa/deploy-aws": "file:packages/litexa-deploy-aws",
     "@litexa/gadgets": "file:packages/litexa-gadgets",
     "@litexa/html": "file:packages/litexa-html",
     "@litexa/integration-tests": "file:tests",
     "@litexa/render-template": "file:packages/litexa-render-template"
-  },
-  "optionalDependencies": {
-    "@litexa/assets-wav": "file:packages/litexa-assets-wav"
   },
   "devDependencies": {
     "assert": "1.4.1",


### PR DESCRIPTION
Added Node.js 12 to CI build matrices. But since the  `lame` package is not compatible in most Node.js 12 environments, we now ignore `@litexa/assets-wav` extension in our build stages in our Node.js 12 CI virtual environments.

Side notes:
* The GitHub Actions `windows-2016` environment is being removed (scheduled for January 2020), so I updated our GitHub Actions to use `windows-2019`. More here https://help.github.com/en/actions/automating-your-workflow-with-github-actions/virtual-environments-for-github-hosted-runners#supported-runners-and-hardware-resources