### PR TITLE
docs: add recommendation to use pauses around speechcons

### DIFF
--- a/docs/book/presentation.md
+++ b/docs/book/presentation.md
@@ -109,7 +109,9 @@ assumed to refer to the `litexa/assets` directory.
 using the "say-as" SSML tag in "interpret-as" mode. Note
 that punctuation should sit inside the speechcon tags in
 order to be read correctly, so you'll want to write
-`<!howdy.>` rather than `<!howdy>.`
+`<!howdy.>` rather than `<!howdy>.` The official
+documentation also recommends surrounding speechcons with a
+pause (e.g, punctuation) for optimal results.
 
 For more information on supported SSML tags, please see the
 [Alexa Skill Kit documentation][ssmltags].


### PR DESCRIPTION
# Title

From observed behavior, it looks like some interjections don't render at all if there is no punctuation, including the one in the litexa docs. Updated docs to recommend punctuation, which reflects the official documentation's recommendation.

## Description

N/A

## Motivation and Context

Ran into this issue while debugging. This is not an obvious conclusion in figuring why speechcons might not work.

## Testing

npm run release

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [X] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
