### PR TITLE
ci: install lerna globally in travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ cache:
     - packages/*/node_modules
 
 install:
-  - npm install -g lerna@3.13.1
-  - if [[ $TRAVIS_NODE_VERSION == "12" ]]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi
+  - 'npm install -g lerna@3.13.1'
+  - 'if [ "${TRAVIS_NODE_VERSION}" == "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi'
 
 stages:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ git:
 cache:
   directories:
     - $HOME/.npm
-    - node_modules
-    - packages/*/node_modules
 
 install:
   - 'npm install -g lerna@3.13.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 
 install:
   - 'npm install -g lerna@3.13.1'
-  - 'if [ "${TRAVIS_NODE_VERSION}" == "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi'
+  - 'if [ "${TRAVIS_NODE_VERSION}" = "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi'
 
 stages:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ cache:
   directories:
     - $HOME/.npm
 
+before_install:
+  - nvm install-latest-npm
+
 install:
-  - 'npm install -g lerna@3.13.1'
-  - 'if [ "${TRAVIS_NODE_VERSION}" = "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi'
+  - if [ $TRAVIS_NODE_VERSION == "12" ]; then nvm install 10 && npm install && nvm use 12; else npm install; fi
 
 stages:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 
 install:
   - npm install -g lerna@3.13.1
-  - if [ $TRAVIS_NODE_VERSION == "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi
+  - if [[ $TRAVIS_NODE_VERSION == "12" ]]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi
 
 stages:
   - name: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
     - packages/*/node_modules
 
 install:
+  - npm install -g lerna@3.13.1
   - if [ $TRAVIS_NODE_VERSION == "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi
 
 stages:


### PR DESCRIPTION
* Remove caching mechanism for `node_modules` to simulate clean, fresh environments for EVERY job in the build pipeline.
* If build job is using Node.js 12, use Node.js 10 while doing `npm install`, and then switch back to Node.js 12 before running the other NPM script(s) in said job. This is a temporary measure to unblock the pipeline that uses Lerna, but needs to be reconciled eventually because it masks any problems that may come up when using Node 12 to `npm install`.