### PR TITLE
chore: reverting "ci: add node 12 to build matrix"

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-2019]
-        node: [10, 12]
+        os: [windows-2016]
+        node: [10]
 
     steps:
     - uses: actions/checkout@master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
-
 node_js:
   - '10'
-  - '12'
-
 os:
   - linux
   - osx
@@ -17,9 +14,6 @@ cache:
     - node_modules
     - packages/*/node_modules
 
-install:
-  - if [ $TRAVIS_NODE_VERSION == "12" ]; then lerna bootstrap --ignore @litexa/assets-wav; else lerna bootstrap; fi
-
 stages:
   - name: build
   - name: coverage
@@ -32,7 +26,7 @@ stages:
 jobs:
   include:
     - stage: build
-      name: 'Build'
+      name: 'Compile'
       script: npm run build
       before_script:
         - echo "$TRAVIS_EVENT_TYPE"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs:build": "npm run docs:reference && npx vuepress build docs",
     "docs:dev": "npx vuepress dev docs",
     "docs:reference": "cd ./packages/litexa && npm run rdoc && npx move-cli ./src/documentation/reference.md ../../docs/reference/README.md && cd ../../",
-    "postinstall": "lerna link convert",
+    "postinstall": "npx lerna bootstrap && npx lerna link convert",
     "release": "npm run build && npm run coverage",
     "test": "npx lerna exec --concurrency 1 npm run test"
   },


### PR DESCRIPTION
Reverting #127. More complexity than first thought when upgrading CI/CD workflows to use Node 12. More information is being tracked in issue #134.