### PR TITLE
docs: flesh out HTML extension's README

### DIFF
--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -268,8 +268,7 @@ Modifying the skill response is currently possible in one of three ways:
 2. directly, by writing a [Litexa extension](extensions.html#_3-runtime-extension) with a
 `beforeFinalResponse` handler which would receive the full response object prior to it being sent.
 3. directly, by writing a function in your skill's project that you then assign to Litexa's
-`responsePostProcessor` handler. Some example use cases:
-    1. @TODO
+`responsePostProcessor` handler.
 
 ## Accepting Novel Events
 

--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -261,12 +261,15 @@ skill-specific in-code `context` handlers.
 
 ## Modifying the Response Object
 
-Modifying the skill response is currently possible in one of two ways:
+Modifying the skill response is currently possible in one of three ways:
 
 1. indirectly, by [modifying response properties](#_2-pending-response-data) in the Litexa
 `context` object, as described above.
 2. directly, by writing a [Litexa extension](extensions.html#_3-runtime-extension) with a
 `beforeFinalResponse` handler which would receive the full response object prior to it being sent.
+3. directly, by writing a function in your skill's project that you then assign to Litexa's
+`responsePostProcessor` handler. Some example use cases:
+    1. @TODO
 
 ## Accepting Novel Events
 

--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -261,14 +261,12 @@ skill-specific in-code `context` handlers.
 
 ## Modifying the Response Object
 
-Modifying the skill response is currently possible in one of three ways:
+Modifying the skill response is currently possible in one of two ways:
 
 1. indirectly, by [modifying response properties](#_2-pending-response-data) in the Litexa
 `context` object, as described above.
 2. directly, by writing a [Litexa extension](extensions.html#_3-runtime-extension) with a
 `beforeFinalResponse` handler which would receive the full response object prior to it being sent.
-3. directly, by writing a function in your skill's project that you then assign to Litexa's
-`responsePostProcessor` handler.
 
 ## Accepting Novel Events
 

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -87,10 +87,10 @@ will likely experience undesired behavior.
 You can use the [`directive`](https://litexa.com/reference/#directive) keyword to add
 HTML directives to your skill responses.
 
-If you're interested in trying out transformers (very similar to
-[APL transformers](https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-data-source.html#transformers)), but want to maintain a skill that can switch
-between HTML and a speaker only presentation, try using the usual Litexa `say` statements, then
-write a [post processor](http://litexa.com/reference/backdoor.html#modifying-the-alexa-response-object)
+If you're interested in trying out transformers in your directives,
+but want to maintain a skill that can switch between an HTML device
+and a speaker only device, try using the usual Litexa `say` statements,
+then write a [post processor](http://litexa.com/reference/backdoor.html#modifying-the-alexa-response-object)
 to conditionally move your outputSpeech into a directive instead.
 
 #### Events

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -52,7 +52,7 @@ interface declaration based on whether or not they were used in your skill, the
 do not plan on using them for all skills, it may be best to use the local installation
 option for each project.
 
-## Alexa Web API Interface
+## Litexa's Alexa Web API Interface
 
 Integrating your skill with the Alexa Web API will allow it to both send and receive data
 from your web app.

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -101,27 +101,6 @@ waitForTransmission
       ...
 ```
 
-## Advanced Features
-
-### 'mark' SSML Tags
-
-In your `.litexa` files, you can add `mark` SSML tags to your speech, like so:
-
-```coffeescript
-launch
-  say "Hello, World!"
-  HTML.mark("screen:blue")
-  END
-```
-
-This will add a substring like `<mark name="screen:blue"/>` to your response's speech.
-This is useful for your HTML runtime in that, when it receives the Alexa response,
-the marks can be used to trigger HTML events that interleave with SSML playback.
-
-@TODO explanation regarding processing marks. It requires:
-1.) a litexa postprocessor that moves (or adds, whatever you want to do) SSML output to HTML message input
-2.) a transformer (explained in Web API docs?) to pull the marks out from the message data and trigger events corresponding to the mark tags.
-
 ## Relevant Resources
 
 For more information, please refer to the official Alexa Web API for Games documentation:

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -19,7 +19,7 @@ for sign-up information.
 Alexa Web API for Games Developer Preview. If you are not in the Developer Preview
 and you have this extension installed, you will not be able to deploy your Alexa
 skills through Litexa. As an additional note, the API is subject to change, which
-may make this extension out of date.
+may leave this extension out of date.
 
 The module can be installed globally, which makes it available to any of your
 Litexa projects:
@@ -46,7 +46,7 @@ project_dir
         └── html
 ```
 
-**WARNING**: Unlike most of the other Litexa extensions which conditionally add the
+**WARNING**: Unlike other Litexa extensions which conditionally add the
 interface declaration based on whether or not they were used in your skill, the
 `@litexa/html` extension will always add the HTML interface to your skill. Thus, if you
 do not plan on using them for all skills, it may be best to use the local installation
@@ -67,11 +67,9 @@ your skill manifest upon deployment.
 #### HTML.isHTMLPresent()
 
 This extension adds a global `HTML` object you can use in both Litexa and code files. It
-has one function, which is to detect whether or not HTML is supported on the user device
-the skill is running on. This is best used in conjunction with conditionally sending HTML
+has one function, which is to detect whether or not HTML is supported on the user's device
+that the skill is running on. This is best used in conjunction with conditionally sending HTML
 directives, since you may want to fall back to APL if HTML is not supported on a device.
-
-For example:
 
 ```coffeescript
 launch
@@ -90,6 +88,14 @@ will likely experience undesired behavior.
 You can use the [`directive`](https://litexa.com/reference/#directive) keyword to add
 HTML directives to your skill responses.
 
+If you're interested in trying out transformers, but want to maintain a skill that can switch
+between HTML and a speaker only presentation, try using the usual Litexa `say` statements, then
+write a [post processor](http://litexa.com/reference/backdoor.html#modifying-the-alexa-response-object)
+to conditionally move your outputSpeech into a directive instead.
+
+
+
+
 #### Events
 
 To handle data that is sent from your web app, add a `when` listener for the
@@ -107,6 +113,6 @@ waitForTransmission
 
 For more information, please refer to the official Alexa Web API for Games documentation:
 
-* [Alexa Web API 
+* [Alexa Web API
 for Games Announcement](https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/11/apply-for-the-alexa-web-api-for-games-developer-preview)
 

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -46,8 +46,8 @@ project_dir
 
 ## Alexa Web API Interface
 
-Integrating with Alexa Web API's directives and events, your skill can both send data to
-and receive data from your web app.
+Integrating your skill with the Alexa Web API will allow it to both send and receive data
+from your web app.
 
 ### Skill Manifest
 

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -7,6 +7,7 @@ visually rich and interactive voice-controlled game experiences. You'll be able 
 for multimodal devices using HTML and web technologies like Canvas 2D, WebAudio, WebGL,
 JavaScript, and CSS, starting with Echo Show devices and Fire TVs.
 
+
 **NOTE**: The Alexa Web API for Games is currently in Developer Preview. To gain access
 to its features & documentation, visit the [Alexa Developer
 Blog](https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/11/apply-for-the-alexa-web-api-for-games-developer-preview)
@@ -47,7 +48,7 @@ project_dir
 
 **WARNING**: Unlike most of the other Litexa extensions which conditionally add the
 interface declaration based on whether or not they were used in your skill, the
-@litexa/html extension will always add the HTML interface to your skill. Thus, if you
+`@litexa/html` extension will always add the HTML interface to your skill. Thus, if you
 do not plan on using them for all skills, it may be best to use the local installation
 option for each project.
 
@@ -66,7 +67,7 @@ your skill manifest upon deployment.
 #### HTML.isHTMLPresent()
 
 This extension adds a global `HTML` object you can use in both Litexa and code files. It
-has 1 function, which is to detect whether or not HTML is supported on the user device
+has one function, which is to detect whether or not HTML is supported on the user device
 the skill is running on. This is best used in conjunction with conditionally sending HTML
 directives, since you may want to fall back to APL if HTML is not supported on a device.
 
@@ -81,7 +82,8 @@ launch
   ...
 ```
 
-**WARNING**: Do not use APL and Web directives in the same response. @TODO: explain conflict
+**WARNING**: Do not use APL and HTML directives in the same response. The user's device
+will likely experience undesired behavior.
 
 #### Directives
 

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -7,7 +7,6 @@ visually rich and interactive voice-controlled game experiences. You'll be able 
 for multimodal devices using HTML and web technologies like Canvas 2D, WebAudio, WebGL,
 JavaScript, and CSS, starting with Echo Show devices and Fire TVs.
 
-
 **NOTE**: The Alexa Web API for Games is currently in Developer Preview. To gain access
 to its features & documentation, visit the [Alexa Developer
 Blog](https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/11/apply-for-the-alexa-web-api-for-games-developer-preview)
@@ -88,13 +87,11 @@ will likely experience undesired behavior.
 You can use the [`directive`](https://litexa.com/reference/#directive) keyword to add
 HTML directives to your skill responses.
 
-If you're interested in trying out transformers, but want to maintain a skill that can switch
+If you're interested in trying out transformers (very similar to
+[APL transformers](https://developer.amazon.com/en-US/docs/alexa/alexa-presentation-language/apl-data-source.html#transformers)), but want to maintain a skill that can switch
 between HTML and a speaker only presentation, try using the usual Litexa `say` statements, then
 write a [post processor](http://litexa.com/reference/backdoor.html#modifying-the-alexa-response-object)
 to conditionally move your outputSpeech into a directive instead.
-
-
-
 
 #### Events
 
@@ -115,4 +112,3 @@ For more information, please refer to the official Alexa Web API for Games docum
 
 * [Alexa Web API
 for Games Announcement](https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/11/apply-for-the-alexa-web-api-for-games-developer-preview)
-

--- a/packages/litexa-html/README.md
+++ b/packages/litexa-html/README.md
@@ -2,9 +2,9 @@
 
 This module adds support for the Alexa Web API for Games.
 
-The Alexa Web API for Games allows you to use existing web technologies and tools to create 
-visually rich and interactive voice-controlled game experiences. You'll be able to build 
-for multimodal devices using HTML and web technologies like Canvas 2D, WebAudio, WebGL, 
+The Alexa Web API for Games allows you to use existing web technologies and tools to create
+visually rich and interactive voice-controlled game experiences. You'll be able to build
+for multimodal devices using HTML and web technologies like Canvas 2D, WebAudio, WebGL,
 JavaScript, and CSS, starting with Echo Show devices and Fire TVs.
 
 **NOTE**: The Alexa Web API for Games is currently in Developer Preview. To gain access
@@ -14,20 +14,20 @@ for sign-up information.
 
 ## Installation
 
-**WARNING**: The use of this extension is currently reserved for those in the 
-Alexa Web API for Games Developer Preview. If you are not in the Developer Preview 
-and you have this extension installed, you will not be able to deploy your Alexa 
+**WARNING**: The use of this extension is currently reserved for those in the
+Alexa Web API for Games Developer Preview. If you are not in the Developer Preview
+and you have this extension installed, you will not be able to deploy your Alexa
 skills through Litexa.
 
-The module can be installed globally, which makes it available to any of your 
+The module can be installed globally, which makes it available to any of your
 Litexa projects:
 
 ```bash
 npm install -g @litexa/html
 ```
 
-If you alternatively prefer installing the extension locally inside your Litexa project, 
-for the sake of tracking the dependency, just run the following inside of your Litexa 
+If you alternatively prefer installing the extension locally inside your Litexa project,
+for the sake of tracking the dependency, just run the following inside of your Litexa
 project directory:
 
 ```bash
@@ -44,7 +44,119 @@ project_dir
         └── html
 ```
 
-## Adding 'mark' SSML Tags
+## Alexa Web API Interface
+
+Integrating with Alexa Web API's directives and events, your skill can both send data to
+and receive data from your web app.
+
+### Skill Manifest
+
+Before your skill can send and receive data through the Alexa Web API, you will need to
+specify the interface in your skill's manifest. You will need to include
+`ALEXA_PRESENTATION_HTML` in your `skill.*` file to let Alexa know that you are using it.
+For example, your skill manifest might look something like this:
+
+```json
+{
+  "manifest": {
+    "apis": {
+      "custom": {
+        "interfaces": [
+          {
+            "type": "ALEXA_PRESENTATION_HTML"
+          }
+        ]
+  ...
+}
+```
+
+### Directives
+
+With Alexa Web API directives, you can send data to your web app from within your skill.
+
+Use the `directive` keyword in your `*.litexa` files to add these directives to your
+Alexa responses. You can get more information about the usage of the `directive` keyword
+from our
+[Litexa language reference](https://litexa.com/reference/#directive).
+
+#### Start Directive
+
+To start your web app, attach the `Alexa.Presentation.HTML.Start` directive to your skill's response.
+Here's an example of what your Litexa code could look like:
+
+```coffeescript
+launch
+    if HTML.isPresent()
+      directive htmlStartDirective(webAppUrl)
+    ...
+```
+
+And the `#htmlStartDirective()` function would return an object like this, and Litexa will add
+it to your skill's response:
+
+```javascript
+function htmlStartDirective(url) {
+    return {
+        type: "Alexa.Presentation.HTML.Start",
+        configuration: {
+            timeoutInSeconds: 1000
+        },
+        data: {},
+        request: {
+            uri: url,
+            method: "GET",
+            headers: {}
+        },
+        transformers: {}
+    };
+}
+```
+
+#### HandleMessage Directive
+
+To send data to your web app, attach the `Alexa.Presentation.HTML.HandleMessage`
+directive to your skill's response. Here's an example of what your Litexa code could look like:
+
+```coffeescript
+fooState
+  when MyIntent
+    directive htmlHandleMessageDirective(message)
+  ...
+```
+
+And the `#htmlHandleMessageDirective()` function would return an object like the one below, and
+Litexa will add it your skill's response:
+
+```javascript
+function htmlHandleMessageDirective(message) {
+    return {
+        type: "Alexa.Presentation.HTML.HandleMessage",
+        message: message,
+        transformers: {}
+    };
+}
+```
+
+### Events
+
+With Alexa Web API events, your skill can receive & handle data sent from your web app.
+
+#### Message Event
+
+To handle data that is sent from your web app, look for the `Alexa.Presentation.HTML.Message`
+event in your `*.litexa` files like you would for an intent-type event (using the `when` keyword).
+For example:
+
+```coffeescript
+barState
+    when Alexa.Presentation.HTML.Message
+      say "I received a message from the web app!"
+    ...
+```
+
+## Advanced Features
+
+### 'mark' SSML Tags
 
 In your `.litexa` files, you can add `mark` SSML tags to your speech, like so:
 
@@ -55,7 +167,7 @@ launch
   END
 ```
 
-This will add a substring like `<mark name="screen:blue"/>` to your response's speech. 
+This will add a substring like `<mark name="screen:blue"/>` to your response's speech.
 This is useful for your HTML runtime in that, when it receives the Alexa response,
 the marks can be used to trigger HTML events that interleave with SSML playback.
 


### PR DESCRIPTION
Fleshing out the HTML extension's README. Making it more clear:

* Add information about the Alexa Web API interface + skill manifest
* Add usage details around the extension's use of the APIs directives & event
* Start to add more details to the `mark` tag section