### PR TITLE
docs: added responsePostProcessor, reorganized backdoor for narrative flow

### DIFF
--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -9,7 +9,6 @@ There are plenty of wonderful Alexa features that Litexa does not yet directly s
 not prevented from using them with a Litexa project! Here are the extension points where you can
 quickly convince Litexa you know better, and have it step out of your way.
 
-
 ## Modifying the Alexa Response Object
 
 The final Litexa product is a response, as specified in [the ASK documentation.](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html)
@@ -55,8 +54,6 @@ code.
   }
 ```
 
-
-
 ## Modifying the Language Model
 
 *Not Yet Available*
@@ -68,10 +65,9 @@ out to us with a proposal for where you feel it would be natural to inject it!
 
 ## Accepting Novel Events
 
-To accept named events that Litexa does not yet define in it's core, you can write
+To accept named events that Litexa does not yet define in its core, you can write
 an extension module, where you indicate the new events in the
 `compiler.valideEventNames` list. [Litexa extension](extensions.html#_2-compiler-extension)
-
 
 ## Sending Novel Directives
 
@@ -199,9 +195,6 @@ See the [chapter on testing](/book/testing.html) for more
 information on tools you have available to help trap and
 correct any errors.
 
-
-
-
 ## Reading and Modifying Litexa's `context`
 
 Litexa's runtime primarily operates by creating and manipulating a `context` object in response
@@ -326,8 +319,6 @@ slot variables, so while handling the following intent, you'd expect to see `con
     ```
 :::
 
-
-
 ### 2) Pending Response Data
 
 The Litexa `context` tracks the following data to be included in any pending response:
@@ -363,7 +354,6 @@ addCustomSSML = function(context) {
 Modifying response data can become especially useful when authoring a custom
 [Litexa extension](extensions.html). For instance, the `@litexa/apl` extension keeps track of all
 APL-related data in a newly added `context.apl` object.
-
 
 ### 3) DB Data
 
@@ -439,7 +429,6 @@ launch
     say "We spoke less than 15 minutes ago, did you miss me?"
   @lastLaunchTime = context.now
 ```
-
 
 In summary, the Litexa `context` object is a good starting point for extending Litexa's
 capabilities, be it through external [Litexa extensions](extensions.html), or through

--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -222,7 +222,7 @@ printObject = function(obj) { console.log(JSON.stringify(obj)); }
 The Litexa `context` is recreated for every new skill request, and contains the following data:
 
 1. incoming request data (e.g. the Alexa skill session attributes)
-2. accumulated response data (e.g. an array of all the say statements hit so far)
+2. accumulated response data (e.g. an array of all the `say` statements hit so far)
 3. DB data (e.g. persistent and transient variables)
 4. utility data (e.g. skill launch time stamp)
 

--- a/docs/book/backdoor.md
+++ b/docs/book/backdoor.md
@@ -1,4 +1,4 @@
-# What About Other Features?
+# What About Other Alexa Features?
 
 Litexa supports Alexa features through a mixture of code shipped with the Litexa core package
 and code added by [Litexa extensions](extensions.html), extra packages that you install alongside
@@ -7,270 +7,71 @@ code.
 
 There are plenty of wonderful Alexa features that Litexa does not yet directly support, but you are
 not prevented from using them with a Litexa project! Here are the extension points where you can
-convince Litexa you know better, and have it step out of your way. If you opt to apply these
-extension points in your own extension, please also refer to the instructions found in
-[Litexa extensions](extensions.html).
+quickly convince Litexa you know better, and have it step out of your way.
 
-## Reading and Modifying Litexa's `context`
 
-Litexa has a `context` object that is accessible within the scope of any Litexa code, and can be
-handed off to inline code as a function parameter:
+## Modifying the Alexa Response Object
 
-```coffeescript
-# main.litexa
-launch
-  printObject(context)
-```
+The final Litexa product is a response, as specified in [the ASK documentation.](https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html)
 
-```js
-// main.js
-printObject = function(obj) { console.log(JSON.stringify(obj)); }
-```
+There are a few reasons you may want to manipulate that response object directly,
+rather than rely on the usual Litexa commands. For example, you may want to log
+how you're responding to an analytics service you run, inject some data into `sessionAttributes`,
+or automatically parse your final accumulated `outputSpeech` to generate other responses
+like cards via a custom function.
 
-This Litexa `context` is recreated for every new skill request, and contains the following data:
+Modifying the skill response is currently possible in one of three ways:
 
-1. incoming request data (e.g. session attributes)
-2. pending response data (e.g. pending output speech)
-3. DB data (e.g. persistent and transient variables)
-4. utility data (e.g. skill launch time stamp)
-
-Let's take a closer look at each of these in turn, along with some common use cases.
-
-### 1) Incoming Request Data
-
-The full incoming request, along with session and system information, is available in
-`context.event`:
-
-```json
-{
-  "version": "1.0",
-  "session": { // SESSION DATA
-    "sessionId": "amzn1.echo-api.session.someId",
-    "application": {
-      "applicationId": "amzn1.ask.skill.someId"
-    },
-    "attributes": {},
-    "user": {
-      "userId": "amzn1.ask.account.someId"
-    }
-  },
-  "context": { // SYSTEM DATA
-    "System": {
-      "device": {
-        "deviceId": "amzn1.ask.device.someId",
-        "supportedInterfaces": {
-          "Alexa.Presentation.APL": {},
-          "Display": {}
-        },
-        "apiEndpoint": "https://api.amazonalexa.com",
-        "apiAccessToken": "someAccessToken"
-      }
-    },
-    "Viewport": {
-      "experiences": [
-        {
-          "arcMinuteWidth": 246,
-          "arcMinuteHeight": 144,
-          "canRotate": false,
-          "canResize": false
-        }
-      ],
-      "shape": "RECTANGLE",
-      "pixelWidth": 1024,
-      "pixelHeight": 600,
-      "dpi": 160,
-      "currentPixelWidth": 1024,
-      "currentPixelHeight": 600,
-      "touch": [
-        "SINGLE"
-      ],
-      "video": {
-        "codecs": [
-          "H_264_42",
-          "H_264_41"
-        ]
-      }
-    }
-  },
-  "request": { // REQUEST DATA
-    "type": "IntentRequest",
-    "requestId": "amzn1.echo-api.request.2f164393-f7c7-410d-8819-eccd49a7f26f",
-    "timestamp": "2017-10-01T22:02:10.000Z",
-    "locale": "en-US",
-    "intent": {
-      "name": "MY_NAME_IS_NAME",
-      "slots": {
-        "name": {
-          "name": "name",
-          "value": "John"
-        }
-      }
-    }
-  }
-}
-```
-
-:::tip Request Data Shortcuts
-There are some useful request data shortcuts available in Litexa:
-
-* `context.event.request` is available as [$request](/reference/#request).
-* `context.event.request.intent.slots` values are populated directly in
-[slot variables](/reference/#slot-variables). For instance:
-
-    ```coffeescript
-    when "my name is $name"
-      with $name = AMAZON.US_FIRST_NAME
-      say "hello $name"
-    ```
-
-    The intent handler (`say "hello $name"`) can directly reference a slot name, which will end up
-    populated with whichever value the user utterance was converted to (for instance, as seen in the
-    above request data, "John").
-
-* `context.event.request.requestId` is available with the shortcut `context.requestId`
-:::
-
-:::tip Request Data Use Cases
-While Litexa makes most request data available/modifiable without requiring the `context` object
-(see shortcuts above), there are several viable scenarios that currently require reading
-the `context` object directly, such as:
-
-* visibility and manipulation of `context.event.session.attributes`
-* visibility of supported interfaces in `context.event.context.System`
-* visibility of device screen specs in `context.event.context.Viewport`
-* etc.
-:::
-
-### 2) Pending Response Data
-
-The Litexa `context` tracks the following data to be included in any pending response:
-
-```json
-{
-  "say": [],        // pending outputSpeech (as specified by 'say' statements)
-  "reprompt": [],   // pending reprompt speech (as specified by 'reprompt' statements)
-  "directives": [], // pending directives (as specified by the 'directive', 'card',
-                    // monetization, and extension statements)
-  "shouldEndSession": false // value explicitly set by 'END' statement,
-                            // or implicitly set by other statements
-}
-```
-
-:::tip Response Data Use Cases
-The response data in `context` can be used to read, modify, or validate the pending response.
-It also allows for changing the response outside of Litexa code, for instance by handing off
-the context to an inline function:
-
-```coffeescript
-# main.litexa
-launch
-  addCustomSSML(context)
-```
-
-```js
-// main.js
-addCustomSSML = function(context) { context.say.push("[myCustomSSML]"); }
-```
-
-Modifying response data can become especially useful when authoring a custom
-[Litexa extension](extensions.html). For instance, the `@litexa/apl` extension keeps track of all
-APL-related data in a newly added `context.apl` object.
-:::
-
-### 3) DB Data
-
-`context.db` allows for directly accessing the DB instance used by Litexa. As an alternative to
-using [`@ variables`](/reference/#variable) to read and write DB data, the same can be achieved by
-directly invoking `context.db.write(String key, data)` and `context.db.read(String key)`.
-
-Among other skill information, the `context.db` object tracks [local variables](/reference/#local)
-and [@ variables](/reference/#variable):
-```json
-{
-  "db": {
-    "variables": {
-      "myKey": {
-        "myData"         // as saved by: @myKey = "myData"
-      }
-    }
-  },
-  "cache": {
-    "__stateLocals": {
-      "myVar": "myValue" // as saved by: local myVar = "myValue"
-    }
-  }
-}
-```
-
-:::warning Litexa-internal DB data
-DB variables stored with the private `'__'` prefix should generally be left untouched: Modifying
-them could negatively impact skill functionality, as they are usually relied on by Litexa's core
-or extension logic.
-:::
-
-### 4) Utility Data
-
-Finally, the `context` object provides some useful utility information for the currently active
-session:
-
-```js
-{
-  "now": 1506895265000,      // time (in milliseconds) of current session launch
-  "language": "default"      // current skill session's language
-  "shouldEndSession": false, // modified by the 'END' statement
-  "settings": {
-    "resetOnLaunch": true    // modified by the 'set [setting] [boolean]' statement
-  },
-  "traceHistory": [          // all states that were visited in current session
-    "launch"
-  ],
-  "monetization": [          // overview of all linked in-skill products
-    "inSkillProducts": [
-      // [reference name]: 'ENTITLED'|'NOT_ENTITLED'
-      { 'myProduct':       'ENTITLED' }
-    ]
-  ]
-}
-```
-
-:::tip Utility Data Use Cases
-This utility data can serve various purposes:
-
-* `context.language` can be used to handle the appropriate language in a
-[Litexa extension](extensions.html). Note, that this is the language defined by Litexa:
-  * any locale that has no specific `languages` directory, as detailed in the documentation
-  on [Localization Project Structure](localization.html#project-structure), is mapped to `default`.
-  * all other locales are mapped to the same name used for their `languages` directory. This would
-  be either a specific locale (`es-es`) or a language code spanning multiple locales (e.g. `es`
-  would override the locales `es-ES` and `es-MX`).
-* `context.traceHistory` can be used for troubleshooting or analytics
-* `context.now` can be used to enable time-based skill variations, such as:
-
-```coffeescript
-launch
-  if minutesBetween(context.now, @lastLaunchTime) < 15
-    say "We spoke less than 15 minutes ago, did you miss me?"
-  @lastLaunchTime = context.now
-```
-
-:::
-
-In summary, the Litexa `context` object is a good starting point for extending Litexa's
-capabilities, be it through external [Litexa extensions](extensions.html), or through
-skill-specific in-code `context` handlers.
-
-## Modifying the Response Object
-
-Modifying the skill response is currently possible in one of two ways:
-
-1. indirectly, by [modifying response properties](#_2-pending-response-data) in the Litexa
-`context` object, as described above.
+1. directly, by installing a `responsePostProcessor` handler.
 2. directly, by writing a [Litexa extension](extensions.html#_3-runtime-extension) with a
-`beforeFinalResponse` handler which would receive the full response object prior to it being sent.
+similar `beforeFinalResponse` handler which would receive the full response object prior
+to it being sent.
+3. indirectly, by [modifying response properties](#_2-pending-response-data) in the Litexa
+`context` object. See details below.
+
+The `responsePostProcessor` is the simplest way to do a one-off custom processor for a single
+skill. It's a single callback you add to the global `litexa` object anywhere in your inline
+code.
+
+```javascript
+  litexa.responsePostProcessor = function( body, context ) {
+    // note: the context argument is the full Litexa context object
+    // the body object is the full response as documented at:
+    // https://developer.amazon.com/en-US/docs/alexa/custom-skills/request-and-response-json-reference.html
+    // any modification you apply to response will be returned to Alexa
+
+    let response = body.response;
+    if ( response.outputSpeech && response.outputSpeech.indexOf('rose') >= 0 ) {
+      response.card = {
+        "type": "Standard",
+        "title": "A Rose For You",
+        "text": "",
+        "image": {
+          "smallImageUrl": "https://there.com/rose-small.png",
+          "largeImageUrl": "https://there.com/rose-large.png"
+        }
+      }
+    }
+  }
+```
+
+
+
+## Modifying the Language Model
+
+*Not Yet Available*
+
+There may be times when manual intervention in the model building process is necessary,
+e.g. you may want to inject some other procedural mechanism for creating values that
+doesn't fit Litexa's slotBuilder scheme. If you have a case like this, please reach
+out to us with a proposal for where you feel it would be natural to inject it!
 
 ## Accepting Novel Events
 
-Coming soon!
+To accept named events that Litexa does not yet define in it's core, you can write
+an extension module, where you indicate the new events in the
+`compiler.valideEventNames` list. [Litexa extension](extensions.html#_2-compiler-extension)
+
 
 ## Sending Novel Directives
 
@@ -398,33 +199,253 @@ See the [chapter on testing](/book/testing.html) for more
 information on tools you have available to help trap and
 correct any errors.
 
-## Modifying the Language Model
 
-Coming soon!
 
-## Customizing the DB Key
 
-By default, Litexa keys any DB entries by the skill session's device ID. If required, this DB key
-can be overridden by adding the following function anywhere in the skill's inline code.
+## Reading and Modifying Litexa's `context`
+
+Litexa's runtime primarily operates by creating and manipulating a `context` object in response
+to each request that comes in. The `context` is accessible within the scope of any Litexa code,
+and can be passed down to inline code as a function parameter:
+
+```coffeescript
+# main.litexa
+launch
+  printObject(context)
+```
 
 ```js
-// The global `litexa` namespace contains compile-time objects at runtime.
-// `overridableFunctions` can be redefined by assigning them to new functionality.
-litexa.overridableFunctions = litexa.overridableFunctions
-                              ? litexa.overridableFunctions
-                              : {};
-
-/* The `identity` parameter will have the following structure:
-{
-  requestAppId,  // = System.application.applicationId
-  userId,        // = System.user.userId
-  deviceId,      // = System.device.deviceId
-  litexaLanguage // = Litexa language (e.g. 'default') for request's locale
-}
-*/
-// Now, let's override the DB key generation.
-litexa.overridableFunctions.generateDBKey = function(identity) {
-  // Create and return the desired DB key.
-  return `${identity.deviceId}|${identity.litexaLanguage}`;
-};
+// main.js
+printObject = function(obj) { console.log(JSON.stringify(obj)); }
 ```
+
+The Litexa `context` is recreated for every new skill request, and contains the following data:
+
+1. incoming request data (e.g. the Alexa skill session attributes)
+2. accumulated response data (e.g. an array of all the say statements hit so far)
+3. DB data (e.g. persistent and transient variables)
+4. utility data (e.g. skill launch time stamp)
+
+Let's take a closer look at each of these in turn, along with some common use cases.
+
+### 1) Incoming Request Data
+
+While Litexa makes most request data available/actionable without requiring
+the `context` object, there are several outlier reasons that
+require reading the `context` object directly, such as:
+
+* visibility and manipulation of `context.event.session.attributes`
+* visibility of supported interfaces in `context.event.context.System`
+* visibility of device screen specs in `context.event.context.Viewport`
+* etc.
+
+The full incoming request, along with session and system information, is available in
+`context.event`:
+
+```json
+{
+  "version": "1.0",
+  "session": { // SESSION DATA
+    "sessionId": "amzn1.echo-api.session.someId",
+    "application": {
+      "applicationId": "amzn1.ask.skill.someId"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.ask.account.someId"
+    }
+  },
+  "context": { // SYSTEM DATA
+    "System": {
+      "device": {
+        "deviceId": "amzn1.ask.device.someId",
+        "supportedInterfaces": {
+          "Alexa.Presentation.APL": {},
+          "Display": {}
+        },
+        "apiEndpoint": "https://api.amazonalexa.com",
+        "apiAccessToken": "someAccessToken"
+      }
+    },
+    "Viewport": {
+      "experiences": [
+        {
+          "arcMinuteWidth": 246,
+          "arcMinuteHeight": 144,
+          "canRotate": false,
+          "canResize": false
+        }
+      ],
+      "shape": "RECTANGLE",
+      "pixelWidth": 1024,
+      "pixelHeight": 600,
+      "dpi": 160,
+      "currentPixelWidth": 1024,
+      "currentPixelHeight": 600,
+      "touch": [
+        "SINGLE"
+      ],
+      "video": {
+        "codecs": [
+          "H_264_42",
+          "H_264_41"
+        ]
+      }
+    }
+  },
+  "request": { // REQUEST DATA
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.2f164393-f7c7-410d-8819-eccd49a7f26f",
+    "timestamp": "2017-10-01T22:02:10.000Z",
+    "locale": "en-US",
+    "intent": {
+      "name": "MY_NAME_IS_NAME",
+      "slots": {
+        "name": {
+          "name": "name",
+          "value": "John"
+        }
+      }
+    }
+  }
+}
+```
+
+:::tip Request Data Shortcuts
+There are some useful request data shortcuts available in Litexa:
+
+* `context.event.request` is available in Litexa code as the request variable [$request](/reference/#request).
+* `context.requestId` is a shortcut to `context.event.request.requestId`
+* `context.slots` contains the Litexa [request variables](/reference/#variable-2). This includes the request
+slot variables, so while handling the following intent, you'd expect to see `context.slots.name` defined.
+
+    ```coffeescript
+    when "my name is $name"
+      with $name = AMAZON.US_FIRST_NAME
+      say "hello $name"
+    ```
+:::
+
+
+
+### 2) Pending Response Data
+
+The Litexa `context` tracks the following data to be included in any pending response:
+
+```json
+{
+  "say": [],        // pending outputSpeech (as specified by 'say' statements)
+  "reprompt": [],   // pending reprompt speech (as specified by 'reprompt' statements)
+  "directives": [], // pending directives (as specified by the 'directive', 'card',
+                    // monetization, and extension statements)
+  "shouldEndSession": false // value explicitly set by 'END' statement,
+                            // or implicitly set by other statements
+}
+```
+
+The response data in `context` can be used to read, modify, or validate the pending response.
+It also allows for changing the response outside of Litexa code, for instance by handing off
+the context to an inline function:
+
+```coffeescript
+# main.litexa
+launch
+  addCustomSSML(context)
+```
+
+```js
+// main.js
+addCustomSSML = function(context) {
+  context.say.push("Hello, I'm <amazon:effect name="whispered">custom.</amazon:effect>");
+}
+```
+
+Modifying response data can become especially useful when authoring a custom
+[Litexa extension](extensions.html). For instance, the `@litexa/apl` extension keeps track of all
+APL-related data in a newly added `context.apl` object.
+
+
+### 3) DB Data
+
+`context.db` allows for directly accessing the DB instance used by Litexa. As an alternative to
+using [`@ variables`](/reference/#variable) to read and write DB data, the same can be achieved by
+directly invoking `context.db.write(String key, data)` and `context.db.read(String key)`.
+
+Among other skill information, the `context.db` object tracks [local variables](/reference/#local)
+that have database storage, and [@ variables](/reference/#variable):
+```json
+{
+  "db": {
+    "variables": {
+      "myKey": {
+        "myData"         // as saved by: @myKey = "myData"
+      }
+    }
+  },
+  "cache": {
+    "__stateLocals": {
+      "myVar": "myValue" // as saved by: local myVar = "myValue"
+    }
+  }
+}
+```
+
+:::warning Litexa-internal DB data
+DB variables stored with the private `'__'` prefix should generally be left untouched: Modifying
+them could negatively impact skill functionality, as they are usually relied on by Litexa's core
+or extension logic.
+:::
+
+### 4) Utility Data
+
+Finally, the `context` object provides some useful utility information for the currently active
+session:
+
+```js
+{
+  "now": 1506895265000,      // time (in milliseconds) when the current request begun processing
+  "language": "default"      // current skill request's Litexa language
+  "shouldEndSession": false, // modified by the 'END' statement
+  "settings": {              // modified by the 'set [setting] [boolean]' statement
+    "resetOnLaunch": true
+  },
+  "traceHistory": [          // all states that have been visited in processing the current request
+    "launch"
+  ],
+  "monetization": [          // overview of all linked in-skill products
+    "inSkillProducts": [
+      // [reference name]: 'ENTITLED'|'NOT_ENTITLED'
+      { 'myProduct':       'ENTITLED' }
+    ]
+  ]
+}
+```
+
+This utility data can serve various purposes:
+
+* `context.language` can be used to handle the appropriate language in a
+[Litexa extension](extensions.html). Note, that this is the language defined by Litexa:
+  * any locale that has no specific `languages` directory, as detailed in the documentation
+  on [Localization Project Structure](localization.html#project-structure), is mapped to `default`.
+  * all other locales are mapped to the same name used for their `languages` directory. This would
+  be either a specific locale (`es-es`) or a language code spanning multiple locales (e.g. `es`
+  would override the locales `es-ES` and `es-MX`).
+* `context.traceHistory` can be used for troubleshooting or analytics
+* `context.now` can be used to enable time-based skill variations, such as:
+
+```coffeescript
+launch
+  if minutesBetween(context.now, @lastLaunchTime) < 15
+    say "We spoke less than 15 minutes ago, did you miss me?"
+  @lastLaunchTime = context.now
+```
+
+
+In summary, the Litexa `context` object is a good starting point for extending Litexa's
+capabilities, be it through external [Litexa extensions](extensions.html), or through
+skill-specific in-code `context` handlers.
+
+
+
+
+

--- a/docs/book/expressions.md
+++ b/docs/book/expressions.md
@@ -247,6 +247,7 @@ askName
     @name = $name
 ```
 
+
 ## DEPLOY Variables
 
 DEPLOY variables are a type of memory storage variable that are references
@@ -310,6 +311,40 @@ statements](/reference/#postfix-conditional) and [file exclusion statements](/re
 Otherwise, if you want to deploy multiple skills where most of their
 logic is the same, you can keep them as one Litexa project with different
 `DEPLOY` object configurations, thereby avoiding code duplication.
+
+
+## Customizing the Litexa DB Key
+
+For variables that have database storage, Litexa maintains a single document in the
+backing database, by default keyed to the Alexa request's deviceId field, meaning that
+the data will be preserved for the skill running on the same Alexa device only.
+
+Should prefer to key on the userId instead (same skill data, no matter which device
+in the same account runs it), or some other field, you can add the following function
+anywhere in the skill's inline code.
+
+```js
+// The global `litexa` namespace contains compile-time objects at runtime.
+// `overridableFunctions` can be redefined by assigning new functionality to them.
+litexa.overridableFunctions = litexa.overridableFunctions
+                              ? litexa.overridableFunctions
+                              : {};
+
+/* The `identity` parameter will have the following structure:
+{
+  requestAppId,  // = System.application.applicationId
+  userId,        // = System.user.userId
+  deviceId,      // = System.device.deviceId
+  litexaLanguage // = Litexa language (e.g. 'default') for request's locale
+}
+*/
+// Now, let's override the DB key generation.
+litexa.overridableFunctions.generateDBKey = function(identity) {
+  // return a key based on both the deviceId and the request langauge
+  return `${identity.deviceId}|${identity.litexaLanguage}`;
+};
+```
+
 
 ## Expressions
 

--- a/docs/book/expressions.md
+++ b/docs/book/expressions.md
@@ -46,6 +46,13 @@ storage to keep track of the current skill state. There
 is only one type of database storage variable, called
 persistent variable.
 
+Note: by default, Litexa is set up to create a new
+database entry for each device that a user invokes
+your skill from, protecting it from interference
+should your skill be invoked at the same time on different
+devices. To modify this, see the section below on
+[Customizing the Litexa DB Key](#customizing-the-litexa-db-key).
+
 ## Value Types
 
 Each variable in Litexa can store one of a number of
@@ -78,7 +85,9 @@ launch
   local b = "here's a string with a second, and third line"
 ```
 
-## Local Variables
+## Variable Types
+
+### Local Variables
 
 The first kind of variable behaves much like
 traditional variables in that they are *lexically
@@ -148,7 +157,7 @@ askForAction
     say "Geez, that only took {loops} tries."
 ```
 
-## Request Variables
+### Request Variables
 
 Request variables live from the moment they are
 declared until the end of the current request, that
@@ -211,7 +220,7 @@ askForAttack
       say "Using the $weapon."
 ```
 
-## Persistent Variables
+### Persistent Variables
 
 Sometimes you need a variable to survive longer than
 both local and request variables. Persistent variables
@@ -247,8 +256,7 @@ askName
     @name = $name
 ```
 
-
-## DEPLOY Variables
+### DEPLOY Variables
 
 DEPLOY variables are a type of memory storage variable that are references
 to static properties of a `DEPLOY` object defined under a deployment
@@ -311,40 +319,6 @@ statements](/reference/#postfix-conditional) and [file exclusion statements](/re
 Otherwise, if you want to deploy multiple skills where most of their
 logic is the same, you can keep them as one Litexa project with different
 `DEPLOY` object configurations, thereby avoiding code duplication.
-
-
-## Customizing the Litexa DB Key
-
-For variables that have database storage, Litexa maintains a single document in the
-backing database, by default keyed to the Alexa request's deviceId field, meaning that
-the data will be preserved for the skill running on the same Alexa device only.
-
-Should prefer to key on the userId instead (same skill data, no matter which device
-in the same account runs it), or some other field, you can add the following function
-anywhere in the skill's inline code.
-
-```js
-// The global `litexa` namespace contains compile-time objects at runtime.
-// `overridableFunctions` can be redefined by assigning new functionality to them.
-litexa.overridableFunctions = litexa.overridableFunctions
-                              ? litexa.overridableFunctions
-                              : {};
-
-/* The `identity` parameter will have the following structure:
-{
-  requestAppId,  // = System.application.applicationId
-  userId,        // = System.user.userId
-  deviceId,      // = System.device.deviceId
-  litexaLanguage // = Litexa language (e.g. 'default') for request's locale
-}
-*/
-// Now, let's override the DB key generation.
-litexa.overridableFunctions.generateDBKey = function(identity) {
-  // return a key based on both the deviceId and the request langauge
-  return `${identity.deviceId}|${identity.litexaLanguage}`;
-};
-```
-
 
 ## Expressions
 
@@ -429,4 +403,36 @@ And the following are dynamic expressions:
   if isCorrectAnswer($answer)
   local playerName = "Ellie"
   if playerName == DEPLOY.name # playerName is not a DEPLOY variable
+```
+
+## Customizing the Litexa DB Key
+
+For variables that have database storage, Litexa maintains a single document in the
+backing database, by default keyed to the Alexa request's deviceId field, meaning that
+the data will be preserved for the skill running on the same Alexa device only.
+
+Should you prefer to key on the userId instead (same skill data, no matter which device
+in the same account runs it), or some other field, you can add the following function
+anywhere in the skill's inline code.
+
+```js
+// The global `litexa` namespace contains compile-time objects at runtime.
+// `overridableFunctions` can be redefined by assigning new functionality to them.
+litexa.overridableFunctions = litexa.overridableFunctions
+                              ? litexa.overridableFunctions
+                              : {};
+
+/* The `identity` parameter will have the following structure:
+{
+  requestAppId,  // = System.application.applicationId
+  userId,        // = System.user.userId
+  deviceId,      // = System.device.deviceId
+  litexaLanguage // = Litexa language (e.g. 'default') for request's locale
+}
+*/
+// Now, let's override the DB key generation.
+litexa.overridableFunctions.generateDBKey = function(identity) {
+  // return a key based on both the deviceId and the request langauge
+  return `${identity.deviceId}|${identity.litexaLanguage}`;
+};
 ```


### PR DESCRIPTION
Added responsePostProcessor documentation to the section on modifying responses.
Organized backdoor.md by cognitive load, with the heavier context object info last. 
Moved the DBKey override information next to the conversation about database storage in the variables pages instead.
