### PR TITLE
fix: fix asset subdirectory path on upload (#153)

### DIFF
--- a/packages/litexa-deploy-aws/src/utils/s3Utils.coffee
+++ b/packages/litexa-deploy-aws/src/utils/s3Utils.coffee
@@ -80,6 +80,7 @@ findAndRegisterFilesToUpload = ({ s3Context, languageInfo }) ->
 
 
 registerFileForUpload = ({ s3Context, fileDir, fileName, language }) ->
+  fileName = fileName.replace /\\/g, '/'
   sourceFilePath = "#{fileDir}/#{fileName}"
   s3Context.assetCount += 1
   s3Key = "#{s3Context.baseLocation}/#{language}/#{fileName}"
@@ -239,6 +240,7 @@ endUploadAssets = ({ s3Context, skillContext, logger }) ->
 module.exports = {
   createAssetSets
   collectUploadInfo
+  findAndRegisterFilesToUpload
   listBucketAndUploadAssets
   prepareBucket
   uploadAssetSet

--- a/packages/litexa-deploy-aws/test/utils/s3Utils.spec.coffee
+++ b/packages/litexa-deploy-aws/test/utils/s3Utils.spec.coffee
@@ -10,6 +10,7 @@
 
 { collectUploadInfo
   createAssetSets
+  findAndRegisterFilesToUpload
   uploadAssetSet
   validateS3BucketName } = require('../../src/utils/s3Utils')
 
@@ -460,6 +461,41 @@ describe 'S3Utils', ->
           }
         }
       )
+
+  describe '#findAndRegisterFilesToUpload()', ->
+    s3Context = {
+      baseLocation: "dummyBase"
+      assets: {}
+    }
+    languageInfo = {
+      default: {
+        assets: {
+          files: ['subdir\\image.png']
+          root: "dummyRoot"
+        }
+        convertedAssets: {
+          files: []
+          root: "dummyRoot"
+        }
+      }
+      en: {
+        assets: {
+          files: ['otherSubdir\\something.png']
+          root: "enDummyRoot"
+        }
+        convertedAssets: {
+          files: []
+          root: "dummyRoot"
+        }
+      }
+    }
+    it 'uploads asset subdirectory files in Windows', ->
+      findAndRegisterFilesToUpload({s3Context, languageInfo})
+      expect(Object.keys(s3Context.assets).length).to.equal(3)
+      asset = s3Context.assets["dummyBase/default/subdir/image.png"]
+      expect(asset).to.not.equal(undefined)
+      expect(asset.name.includes('\\')).to.equal(false)
+      expect(asset.sourceFilename.includes('\\')).to.equal(false)
 
 
   describe '#uploadAssetSet()', ->


### PR DESCRIPTION
# fix asset subdirectory path on upload (#153)
Fixes #153.

## Description

Windows subdirectories use the "\\" character, which is not valid in S3 asset paths during the step where Litexa searches for all assets that need to be uploaded.

## Motivation and Context

#153 

## Testing
npm run test in litexa deploy package

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
