### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -63,6 +63,10 @@ module.exports = {
   title: 'litexa',
   description: 'A domain specific language for building Alexa skills',
   themeConfig: {
+    algolia: {
+      apiKey: '33046bfd9da3c88f198ad313db688f1f',
+      indexName: 'litexa'
+    },
     nav, sidebar,
     sidebarDepth: 3,
     repo: 'alexa-games/litexa',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow a user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.