### PR TITLE
fix: adding support for escaped quote characters in say strings

### DIFF
--- a/packages/litexa/src/parser/litexa.pegjs
+++ b/packages/litexa/src/parser/litexa.pegjs
@@ -2812,6 +2812,7 @@ TemplateStringEscapedCharacterPart
   = '\\$' { return new lib.StringPart('$'); }
   / '\\@' { return new lib.StringPart('@'); }
   / '\\<' { return new lib.StringPart('<'); }
+  / '\\"' { return new lib.StringPart('\\"'); }
   / '\\\\' { return new lib.StringPart('\\'); }
   / '\\' symbol:'{' {
     // note: pegjs parser had trouble with using the symbol character in the action
@@ -3270,9 +3271,13 @@ __r "white space including line breaks"
   = (WhiteSpace/LineTerminatorSequence)*
 
 QuotedString
-  = '"' __ inner:$(!'"' .)* '"' {
-    return inner;
+  = '"' __ inner:QuotedStringCharacter* '"' {
+    return inner.join('');
   }
+
+QuotedStringCharacter
+  = '\\"' { return '"'; }
+  / !'"' a:. { return a; }
 
 
 RegionCode

--- a/tests/data/say-formatting/litexa/main.litexa
+++ b/tests/data/say-formatting/litexa/main.litexa
@@ -1,17 +1,17 @@
 launch
   say "There should be
-    a space    between   
+    a space    between
     word and salad here: word {'salad'}."
-  say " There   
-    is   
-    {'1'}   
-    space     
-    {'between'}    
-    each  
-    word. 
+  say " There
+    is
+    {'1'}
+    space
+    {'between'}
+    each
+    word.
     {'hi'}"
   say "There should also be a space between space and cats here: {'space'}  {'cats'}."
-  
+
   when AIntent
     or "a"
     say "{'Interpolated text'} begins this sentence."
@@ -26,7 +26,7 @@ launch
       primaryText: "<b> this is one
         continuous {'line'} {'on'}
         <center>a screen. But this is
-        
+
         not a continuous line."
       displaySpeechAs: "secondaryText"
       hint: "some hint"
@@ -48,19 +48,19 @@ launch
   when CIntent
     or "c"
     say "{'Start'}
-      middle   
+      middle
       end."
     say "Start
-      {'middle'}   
+      {'middle'}
       end."
     say "Start
-      middle   
+      middle
       {'end.'}"
     screen
       primaryText: "{'start'}
-      
+
       {'end'}"
-  
+
   when DIntent
     or "d"
     say "{'There'} should be a space
@@ -69,7 +69,7 @@ launch
   when EscapesTest
     say "\<amazon:effect name='whispered'>Hi. I am not a human.\</amazon:effect>"
     say "That will be \$400 please."
-    # say "Oh, you mean \"that\" thing." # TODO: fix. This should not result in a syntax error
+    say "Oh, you mean \"that\" thing." # TODO: fix. This should not result in a syntax error
     say "Her Twitter handle was \@martina."
 
   when PunctuationTest
@@ -94,6 +94,6 @@ TEST "say statement"
   user: "d"
   alexa: launch, /There should be a space between 'there' and 'should'\./i
   user: EscapesTest
-  alexa: launch, e"<amazon:effect name='whispered'>Hi. I am not a human.</amazon:effect> That will be $400 please. Her Twitter handle was @martina."
+  alexa: launch, e"<amazon:effect name='whispered'>Hi. I am not a human.</amazon:effect> That will be $400 please. Oh, you mean \"that\" thing. Her Twitter handle was @martina."
   user: PunctuationTest
   alexa: launch, /Start word\!\?:;,\./i


### PR DESCRIPTION
Quick fix for an oldie closing #116 allowing the syntax say "that \"thing\" you said"
Note, while this doesn't appear to do anything in most SSML renderers, it is valid syntax so we'll support it.

## Testing

Tested on OSX, with node v10.21.0, ran the test suite.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
