### PR TITLE
fix: allow characters outside basic ASCII into invocation names

### DIFF
--- a/packages/litexa/src/command-line/deploy/manifest.coffee
+++ b/packages/litexa/src/command-line/deploy/manifest.coffee
@@ -236,8 +236,10 @@ buildSkillManifest = (context, manifestContext) ->
           mergeManifest.publishingInformation.locales[locale] = copy
 
           invocationName = context.deploymentOptions.invocation?[locale] ? data.invocation ? data.name
-          invocationName = invocationName.replace /[^a-zA-Z0-9 ]/g, ' '
-          invocationName = invocationName.toLowerCase()
+          # until such time we can correctly define the acceptable character set, we're
+          # better off disabling this sanitization here and letting SMAPI fail and error out.
+          #invocationName = invocationName.replace /[^a-zA-Z0-9 ]/g, ' '
+          #invocationName = invocationName.toLowerCase()
 
           if context.deploymentOptions.invocationSuffix?
             invocationName += " #{context.deploymentOptions.invocationSuffix}"


### PR DESCRIPTION
Disabling litexa side sanitization in favor of hitting the SMAPI error instead, which makes the string permissive enough to cover anything SMAPI will accept. It's rare enough to change invocation names, so trying to discover the error earlier doesn't help much here.

This closes #129 

## Motivation and Context

Support invocation names that contain characters languages other than EN.

## Testing

Tested on OSX with node version v10.21.0. Ran test suite, and deployed a test skill with the name "die Prüfung"

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
