### PR TITLE
chore: add nodejs versions 12 and 14 to the travis test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - '10'
+  - '12'
+  - '14'
 os:
   - linux
   - osx

--- a/packages/litexa-deploy-aws/src/lambda.coffee
+++ b/packages/litexa-deploy-aws/src/lambda.coffee
@@ -245,7 +245,7 @@ packZipFile = (context, logger, lambdaContext) ->
         zipper.writeZip lambdaContext.zipFilename
 
       zipLog = path.join context.deployRoot, 'zip.out.log'
-      fs.writeFileSync zipLog, stdout
+      fs.writeFileSync zipLog, stdout ? ''
       zipLog = path.join context.deployRoot, 'zip.err.log'
       fs.writeFileSync zipLog, "" + err + stderr
       if err?


### PR DESCRIPTION
Bumping up the travis coverage to all node versions that should be currently supported.

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
