### PR TITLE
fix: ignore ASK cli [Warn] async messages during deploy

### DIFF
--- a/packages/litexa/src/command-line/api/smapi.coffee
+++ b/packages/litexa/src/command-line/api/smapi.coffee
@@ -95,7 +95,10 @@ module.exports = {
             throw "SMAPI command '#{command}' failed, without an error message"
 
         if data.stderr
-          logger.warning data.stderr
+          do ->
+            # we can filter this one out, as it can be confusing in the litexa output
+            return if data.stderr.match /This is an asynchronous operation/
+            logger.warning data.stderr
 
         responseKey = "\nResponse:\n"
         responsePos = data.stdout.indexOf responseKey

--- a/packages/litexa/src/command-line/api/smapi.coffee
+++ b/packages/litexa/src/command-line/api/smapi.coffee
@@ -96,8 +96,14 @@ module.exports = {
           logger.verbose "SMAPI statusCode #{response.statusCode}"
           data.stdout = JSON.stringify response.body, null, 2
 
-      if data.stderr and data.stderr.indexOf('ETag') < 0
-        throw data.stderr
+      if data.stderr
+        if data.stderr.indexOf('ETag') >= 0
+          # some v1 commands returned an ETag, don't need it
+        else if data.stderr.indexOf('This is an asynchronous operation') >= 0
+          # some v2 commands returned a warning, we can ignore those
+        else
+          throw data.stderr
+
       Promise.resolve data.stdout
     .catch (err) ->
       if typeof(err) != 'string'


### PR DESCRIPTION
This adds minor logic to ignore messages about asynchronous processes in ask-cli SMAPI mode, rather than treat them as an error.

## Motivation and Context

This was preventing deployments if the user had upgraded to ask-cli v2.11 or newer. 

## Testing

Tested deploying a new default skill, then updating it from a Mac, with node v10.21.0 & v12.13.1 and ask-cli v2.11.2 & v1.7.23

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
