### PR TITLE
fix: request parser always injects extensions

### DIFF
--- a/packages/litexa/src/parser/handler.coffee
+++ b/packages/litexa/src/parser/handler.coffee
@@ -19,7 +19,7 @@ shouldUniqueURLs = process?.env?.shouldUniqueURLs == 'true'
 # assets root location is determined by an external variable
 litexa.assetsRoot = process?.env?.assetsRoot ? litexa.assetsRoot
 
-handlerSteps = {}
+exports.handlerSteps = handlerSteps = {}
 
 exports.handler = (event, lambdaContext, callback) ->
 
@@ -258,6 +258,8 @@ handlerSteps.parseRequestData = (stateContext) ->
   if request.type == 'LaunchRequest'
     reportValueMetric 'Launches'
 
+  initializeExtensionObjects stateContext
+
   switch request.type
     when 'IntentRequest', 'LaunchRequest'
       incomingState = stateContext.currentState
@@ -326,8 +328,6 @@ handlerSteps.parseRequestData = (stateContext) ->
 
       unless handled
         throw new Error "unrecognized event type: #{request.type}"
-
-  initializeExtensionObjects stateContext
 
 
 handlerSteps.initializeMonetization = (stateContext, event) ->

--- a/packages/litexa/test/specs/parser/handler.spec.coffee
+++ b/packages/litexa/test/specs/parser/handler.spec.coffee
@@ -1,0 +1,41 @@
+###
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+###
+
+Utils = require('@src/parser/utils').lib
+{assert, expect} = require('chai')
+
+describe 'parses request data', ->
+  global.litexa = {
+    extendedEventNames: [],
+    overridableFunctions: {
+      generateDBKey: () -> 'key'
+    }
+  }
+  global.extensionEvents = {}
+  global.extensionRequests = {}
+
+  # needs to come after injecting globals
+  Handler = require('@src/parser/handler')
+
+  it 'installs extensions before parsing', ->
+    global.initializeExtensionObjects = ->
+        global.extensionRequests['testExtension'] = {
+          testIntent: (req) -> 
+            console.log('installing intent')
+        }
+
+    resp = Handler.handlerSteps.parseRequestData({
+      settings: { resetOnLaunch: true },
+      event: { request: { type: 'testIntent' }, session: { attributes: {} } },
+      request: { type: 'testIntent' },
+      db: { 
+        read: () -> , 
+        write: () -> 
+      }
+    })
+
+    


### PR DESCRIPTION
# Title

Injects extensions before the parser needs to use them

## Description
Injects extensions before parser tries to use them

## Motivation and Context
Currently only injects extensions if the first request is a standard supported use case. This prevents extensions from working on custom intent types.

https://github.com/alexa-games/litexa/issues/201

## Testing
Added a new unit test and verified in a live litexa skill

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

<!--- Litexa is released under the [Apache License, Version 2.0][license], so any code you submit will be released under that license. -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla]. -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license: -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/alexa-games/litexa/issues
[license]: https://www.apache.org/licenses/LICENSE-2.0
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
